### PR TITLE
Fix all-day reminders showing a day early in today/upcoming/overdue

### DIFF
--- a/remctl
+++ b/remctl
@@ -1257,6 +1257,23 @@ def display_due_expr(db, table_alias="r"):
 def due_expr(table_alias="r"):
     return f"{table_alias}.ZDUEDATE"
 
+def due_filter_expr(db, table_alias="r"):
+    """Date used for due-window bucketing (today/upcoming/overdue).
+
+    All-day reminders store ZDUEDATE at midnight UTC, so for any timezone west
+    of UTC the raw value lands on the previous local day (and east of UTC, the
+    next day). The Reminders app buckets all-day items by their local-anchored
+    display date instead, so we match that: prefer ZDISPLAYDATEDATE for all-day
+    reminders, and keep the exact due time for timed reminders.
+    """
+    due = f"{table_alias}.ZDUEDATE"
+    if reminder_has_column(db, "ZALLDAY") and reminder_has_column(db, "ZDISPLAYDATEDATE"):
+        return (
+            f"(CASE WHEN {table_alias}.ZALLDAY = 1 "
+            f"THEN COALESCE({table_alias}.ZDISPLAYDATEDATE, {due}) ELSE {due} END)"
+        )
+    return due
+
 def rem_cols(db):
     return f"""r.Z_PK, r.ZTITLE, r.ZNOTES, r.ZCOMPLETED, r.ZFLAGGED, r.ZPRIORITY,
     {urgent_column_expr(db)} AS ZISURGENTSTATEENABLEDFORCURRENTUSER,
@@ -1589,7 +1606,7 @@ def q_search(db, query, completed=False):
 
 def q_due_today(db, include_overdue=True):
     sod, eod = due_today_window()
-    due_column = due_expr()
+    due_column = due_filter_expr(db)
     if include_overdue:
         w = f"{due_column} < {to_ts(eod)} AND {due_column} IS NOT NULL"
     else:
@@ -1619,7 +1636,7 @@ def q_urgent(db):
 def q_upcoming(db, days=7):
     """Reminders due within the next N days (not overdue)."""
     sod, future = upcoming_window(days)
-    due_column = due_expr()
+    due_column = due_filter_expr(db)
     return db.execute(
         f"SELECT {rem_cols(db)} FROM ZREMCDREMINDER r LEFT JOIN ZREMCDBASELIST l "
         f"ON r.ZLIST = l.Z_PK WHERE r.ZMARKEDFORDELETION = 0 AND r.ZCOMPLETED = 0 AND r.ZACCOUNT IS NOT NULL "
@@ -1631,7 +1648,7 @@ def q_upcoming(db, days=7):
 def q_overdue(db):
     """All overdue incomplete reminders."""
     sod = start_of_day()
-    due_column = due_expr()
+    due_column = due_filter_expr(db)
     return db.execute(
         f"SELECT {rem_cols(db)} FROM ZREMCDREMINDER r LEFT JOIN ZREMCDBASELIST l "
         f"ON r.ZLIST = l.Z_PK WHERE r.ZMARKEDFORDELETION = 0 AND r.ZCOMPLETED = 0 AND r.ZACCOUNT IS NOT NULL "
@@ -1641,7 +1658,7 @@ def q_overdue(db):
 
 # ── Format ───────────────────────────────────────────────────────────────────
 
-def fmt_due(v, colored=True):
+def fmt_due(v, colored=True, all_day=False):
     if not v: return ""
     if isinstance(v, datetime):
         dt = v
@@ -1657,7 +1674,7 @@ def fmt_due(v, colored=True):
     now = datetime.now()
     today = now.replace(hour=0, minute=0, second=0, microsecond=0)
     if dt.date() == today.date():
-        label = f" (today {dt.strftime('%H:%M')})" if dt.hour or dt.minute else " (today)"
+        label = f" (today {dt.strftime('%H:%M')})" if not all_day and (dt.hour or dt.minute) else " (today)"
         return label
     if dt.date() == (today + timedelta(days=1)).date():
         return " (tomorrow)"
@@ -1697,6 +1714,21 @@ def _item_get(item, key, default=None):
     if _item_has(item, key):
         return item[key]
     return default
+
+
+def row_effective_due(item):
+    """Raw due timestamp used for day bucketing, honoring all-day display dates.
+
+    Mirrors due_filter_expr() for in-Python partitioning/grouping: all-day
+    reminders store ZDUEDATE at midnight UTC, so bucket them by their
+    local-anchored ZDISPLAYDATEDATE when present.
+    """
+    due = _item_get(item, "ZDUEDATE")
+    if _item_get(item, "ZALLDAY"):
+        display = _item_get(item, "ZDISPLAYDATEDATE")
+        if display is not None:
+            return display
+    return due
 
 
 def _priority_value_from_item(item):
@@ -1833,7 +1865,14 @@ def fmt(r, db=None, verbose=False, indent="", _sc=None, _ht=None):
     pri_str = f" {_color_priority(pri_val)}" if PRI.get(pri_val, "") else ""
     id_str = reminder_id_from_item(r, db)
     title = safe_display((r["ZTITLE"] if _item_has(r, "ZTITLE") else _item_get(r, "title")) or "(untitled)")
-    due_str = fmt_due(r["ZDUEDATE"] if _item_has(r, "ZDUEDATE") else _item_get(r, "dueDate"))
+    if _item_has(r, "ZDUEDATE"):
+        all_day = bool(_item_get(r, "ZALLDAY"))
+        due_val = row_effective_due(r)
+    else:
+        all_day = bool(_item_get(r, "allDay"))
+        display = _item_get(r, "displayDate")
+        due_val = display if (all_day and display is not None) else _item_get(r, "dueDate")
+    due_str = fmt_due(due_val, all_day=all_day)
     repeat_badge = recurrence_badge(r)
     recur_str = f" {repeat_badge}" if repeat_badge else ""
     if completed:
@@ -5673,7 +5712,7 @@ def cmd_today(a):
         print(f"Nothing due today ({datetime.now().strftime('%Y-%m-%d')})")
         return
     sod = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-    overdue = [i for i in items if ts(i["ZDUEDATE"]) < sod]
+    overdue = [i for i in items if ts(row_effective_due(i)) < sod]
     overdue_pks = {i["Z_PK"] for i in overdue}
     due = [i for i in items if i["Z_PK"] not in overdue_pks]
     if overdue:
@@ -6048,7 +6087,7 @@ def cmd_upcoming(a):
     # Group by day
     groups = {}
     for i in items:
-        dt = ts(i["ZDUEDATE"])
+        dt = ts(row_effective_due(i))
         day_key = dt.strftime("%Y-%m-%d")
         day_label = dt.strftime("%A, %b %d")
         today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,9 +4,11 @@ import contextlib
 import base64
 import io
 import json
+import os
 import sqlite3
 import sys
 import tempfile
+import time
 import unittest
 import uuid
 from pathlib import Path
@@ -3960,6 +3962,116 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["earlyReminder"]["unitCode"], 0)
         self.assertEqual(payload["earlyReminder"]["count"], -15)
         self.assertEqual(payload["earlyReminders"][0]["identifier"], "DELTA-1")
+
+    def _due_window_db(self):
+        """Minimal reminders schema for due-window query tests."""
+        db = sqlite3.connect(":memory:")
+        db.row_factory = sqlite3.Row
+        db.execute(
+            "CREATE TABLE ZREMCDREMINDER ("
+            "Z_PK INTEGER PRIMARY KEY, ZTITLE TEXT, ZNOTES TEXT, ZCOMPLETED INTEGER, "
+            "ZFLAGGED INTEGER, ZPRIORITY INTEGER, ZISURGENTSTATEENABLEDFORCURRENTUSER INTEGER, "
+            "ZDUEDATEDELTAALERTSDATA TEXT, ZDUEDATE REAL, ZDISPLAYDATEDATE REAL, ZALLDAY INTEGER, "
+            "ZCOMPLETIONDATE REAL, ZCREATIONDATE REAL, ZPARENTREMINDER INTEGER, ZLIST INTEGER, "
+            "ZICSURL TEXT, ZCKIDENTIFIER TEXT, ZACCOUNT INTEGER, ZMARKEDFORDELETION INTEGER)"
+        )
+        db.execute("CREATE TABLE ZREMCDBASELIST (Z_PK INTEGER PRIMARY KEY, ZNAME TEXT)")
+        # Referenced by the recurrence subqueries in rem_cols(); empty is fine.
+        db.execute(
+            "CREATE TABLE ZREMCDOBJECT ("
+            "Z_PK INTEGER, Z_ENT INTEGER, ZREMINDER4 INTEGER, ZMARKEDFORDELETION INTEGER, "
+            "ZFREQUENCY INTEGER, ZINTERVAL INTEGER, ZOCCURRENCECOUNT INTEGER, ZENDDATE REAL, "
+            "ZDAYSOFTHEWEEK BLOB, ZDAYSOFTHEMONTH BLOB, ZMONTHSOFTHEYEAR BLOB, "
+            "ZDAYSOFTHEYEAR BLOB, ZWEEKSOFTHEYEAR BLOB, ZSETPOSITIONS BLOB)"
+        )
+        db.execute("INSERT INTO ZREMCDBASELIST (Z_PK, ZNAME) VALUES (1, 'Inbox')")
+        return db
+
+    def _insert_due_reminder(self, db, pk, title, *, due_ts, display_ts, all_day):
+        db.execute(
+            "INSERT INTO ZREMCDREMINDER "
+            "(Z_PK, ZTITLE, ZCOMPLETED, ZFLAGGED, ZPRIORITY, ZDUEDATE, ZDISPLAYDATEDATE, "
+            "ZALLDAY, ZLIST, ZCKIDENTIFIER, ZACCOUNT, ZMARKEDFORDELETION) "
+            "VALUES (?, ?, 0, 0, 0, ?, ?, ?, 1, ?, 1, 0)",
+            (pk, title, due_ts, display_ts, 1 if all_day else 0, f"CK-{pk}"),
+        )
+
+    def test_all_day_reminders_bucket_by_display_date_west_of_utc(self):
+        from datetime import datetime, timedelta, timezone
+
+        # All-day reminders store ZDUEDATE at midnight UTC, which lands on the
+        # previous local day west of UTC. Pin a fixed western zone so the bug
+        # is reproducible regardless of where the suite runs.
+        prev_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "America/New_York"
+        time.tzset()
+        self.remctl._REMINDER_COLUMN_CACHE.clear()
+        db = self._due_window_db()
+        try:
+            apple_epoch = self.remctl.APPLE_EPOCH
+
+            def utc_midnight_ts(d):
+                dt = datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
+                return dt.timestamp() - apple_epoch
+
+            today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            tomorrow = today + timedelta(days=1)
+
+            # All-day due today: display anchored to local midnight today,
+            # raw due at midnight UTC today (lands "yesterday evening" locally).
+            self._insert_due_reminder(
+                db, 1, "AllDay Today",
+                due_ts=utc_midnight_ts(today),
+                display_ts=self.remctl.to_ts(today),
+                all_day=True,
+            )
+            # All-day due tomorrow: the reported bug. Raw due lands today locally.
+            self._insert_due_reminder(
+                db, 2, "AllDay Tomorrow",
+                due_ts=utc_midnight_ts(tomorrow),
+                display_ts=self.remctl.to_ts(tomorrow),
+                all_day=True,
+            )
+            # Timed reminder due today at 9am: due == display, must be unaffected.
+            timed_due = self.remctl.to_ts(today.replace(hour=9))
+            self._insert_due_reminder(
+                db, 3, "Timed Today",
+                due_ts=timed_due, display_ts=timed_due, all_day=False,
+            )
+
+            # Sanity: the all-day-tomorrow raw due really does fall on today
+            # locally, so this exercises the timezone shift (not a no-op).
+            raw_tomorrow_due = db.execute(
+                "SELECT ZDUEDATE FROM ZREMCDREMINDER WHERE Z_PK = 2"
+            ).fetchone()["ZDUEDATE"]
+            self.assertEqual(self.remctl.ts(raw_tomorrow_due).date(), today.date())
+
+            due_today = self.remctl.q_due_today(db, include_overdue=True)
+            titles = {row["ZTITLE"] for row in due_today}
+            self.assertEqual(titles, {"AllDay Today", "Timed Today"})
+
+            # Nothing is overdue: the all-day-today item must not be misfiled.
+            self.assertEqual(self.remctl.q_overdue(db), [])
+
+            # Upcoming groups the all-day-tomorrow item under tomorrow, not today.
+            upcoming = {row["ZTITLE"]: row for row in self.remctl.q_upcoming(db, days=7)}
+            self.assertIn("AllDay Tomorrow", upcoming)
+            effective = self.remctl.row_effective_due(upcoming["AllDay Tomorrow"])
+            self.assertEqual(self.remctl.ts(effective).date(), tomorrow.date())
+
+            # The human label must match the bucket: "(tomorrow)", with no
+            # spurious all-day time leaking through from the UTC-midnight due.
+            rendered = self.remctl._strip_ansi(self.remctl.fmt(upcoming["AllDay Tomorrow"]))
+            self.assertIn("(tomorrow)", rendered)
+            self.assertNotIn("20:00", rendered)
+        finally:
+            db.close()
+            self.remctl._REMINDER_COLUMN_CACHE.clear()
+            if prev_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = prev_tz
+            time.tzset()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

All-day reminders show up on the wrong day in `today`, `upcoming`, and
`overdue`. For users west of UTC they appear a day early (an all-day reminder
due tomorrow shows as "due today"); east of UTC they'd appear a day late.

## Cause

Apple stores all-day reminders' `ZDUEDATE` at **midnight UTC** of the target
day, while `ZDISPLAYDATEDATE` holds the local-anchored date the Reminders app
actually displays by. The date-window queries bucketed purely on the raw
`ZDUEDATE`, so the UTC offset pushed all-day items into the adjacent local day.

## Fix

- `due_filter_expr()` — buckets all-day reminders by
  `COALESCE(ZDISPLAYDATEDATE, ZDUEDATE)`, keeping exact times for timed
  reminders. Used in `q_due_today`, `q_upcoming`, `q_overdue` (WHERE + ORDER BY).
- `row_effective_due()` — Python mirror for `cmd_today`'s overdue/due split and
  `cmd_upcoming`'s day grouping.
- `fmt_due()`/`fmt()` render all-day reminders by their effective date and drop
  the spurious midnight-artifact time so the inline label matches its group.

## Tests

Added `test_all_day_reminders_bucket_by_display_date_west_of_utc`, which pins
`TZ=America/New_York` and covers an all-day-today item, the all-day-tomorrow
regression, and an unaffected timed reminder, plus the human-readable label.
Confirmed it fails on the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)