### PR TITLE
Multi-account support and correct live-store selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Full setup details live in [docs/installation.md](docs/installation.md).
 | Create and edit | `add`, `edit`, `done`, `undone`, `delete`, `flag`, `unflag` |
 | Organize | `list-symbols`, `list-create`, `list-edit`, `list-pin`, `list-unpin`, `list-rename`, `list-delete`, `smart-list-create`, `smart-list-edit`, `smart-list-delete`, `template-create`, `template-apply`, `template-delete`, `sections`, `tags` |
 | Share data | `export`, `import`, `link`, `open`, `--json`, `--format table` on tabular read commands |
+| Work across accounts | `accounts`, `config`, `--all-accounts` and `--account NAME` on read and write commands |
 | Set up the Mac | `onboard`, `permissions`, `doctor`, `setup`, `completion` |
 
 Common examples:
@@ -98,7 +99,12 @@ remctl list-edit Projects --private --color orange --symbol education3
 remctl list-pin "Project X" --private
 remctl list-rename --list-id 123 --new-name "Project X Archive"
 remctl info 23880 --json
+remctl accounts
+remctl today --all-accounts
+remctl add "Send invoice" -l Tasks --account Exchange
 ```
+
+RemCTL works across every Reminders account on the Mac — iCloud, Exchange, and on-device local. By default it operates on your primary account; add `--all-accounts` to any read command to see everything at once (grouped by account), or `--account NAME` to target a specific account for reads and writes. Run `remctl accounts` to list them, and set a personal default with `remctl config accountScope all`. See [Multi-Account in the command guide](docs/commands.md#multi-account).
 
 The full command guide is in [docs/commands.md](docs/commands.md). For smart lists specifically, start with [Smart Lists in the command guide](docs/commands.md#smart-lists), then read [Private Metadata Writes: Smart List Examples](docs/private-metadata.md#smart-list-examples) for the ReminderKit write path, guardrails, and implementation notes. Template commands are covered in [docs/commands.md#templates](docs/commands.md#templates) and [docs/private-metadata.md#template-examples](docs/private-metadata.md#template-examples).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -84,6 +84,18 @@ remctl list-delete --list-id 123 --force --json
 - Commands that target lists consistently support exact numeric targeting where the underlying write/read path is safe: `show --list-id`, `add --list-id`, `edit --list-id`, `link --list-id`, `export --list-id`, `list-edit --list-id`, `list-pin --list-id`, `list-unpin --list-id`, `list-rename --list-id --new-name`, `list-delete --list-id`, plus smart-list `--include-list-id`. `list-pin` and `list-unpin` also accept smart-list names or `--smart-list-id`.
 - If a command accepts both a list name and `--list-id`, passing both is an error.
 
+## Multi-Account
+
+- The Mac may have several Reminders accounts (iCloud, Exchange, on-device local). By default every command operates on the primary account only; existing single-account behavior is unchanged.
+- `remctl accounts` lists connected accounts with their type. Run it first when the user mentions work/Exchange reminders or multiple accounts.
+- Read commands accept `--all-accounts` (every account, grouped/labeled) and `--account NAME` (one account). `--json` adds `account`/`accountType` fields; `--format table` adds an Account column.
+- Write commands (`add`, `done`, `undone`, `edit`, `delete`, `flag`, `unflag`) accept `--account NAME`. Account flags may be placed before or after the command.
+- Reminder IDs (`Z_PK`) are unique only within an account. When the scope spans multiple accounts, a bare ID that exists in more than one account is rejected with a disambiguation error — pass `--account` to resolve it.
+- Prefer `--account NAME` over a bare ID when acting on a non-primary account, and use `remctl accounts` plus `show <list> --account NAME --json` to find the correct ID first.
+- A user can set a default scope with `remctl config accountScope all` (or an account name); `REMCTL_ACCOUNT_SCOPE` is the environment-variable equivalent.
+- Non-iCloud accounts (Exchange/CalDAV) support create/edit/complete/delete (changes sync to the server) but not `flag`/`unflag` (no flag attribute) or `link`/`open` deep links. Microsoft To Do "Important (starred)" tasks sync in as **priority**, not flags — surface them with priority, and use `edit <id> -p high` rather than `flag`.
+- Exchange/CalDAV sync is not instant (unlike iCloud). A write applies locally immediately but can take a minute or two to reach the server; don't re-issue the command if the server hasn't caught up yet. The local `ZEXTERNALIDENTIFIER` field is not a reliable "synced" indicator — it populates only on the return sync.
+
 ## Recurring Schedules
 
 Recurring schedules are normal EventKit writes and do not require `--private`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,11 +25,15 @@ There is no daemon, localhost API, launch agent, or token setup in RemCTL 1.0. T
 
 ## Reads
 
-Direct reads use the iCloud Reminders CoreData store:
+Direct reads use the Reminders CoreData stores. Each account (iCloud, Exchange,
+CalDAV, on-device local) has its own database file in the Stores directory:
 
 ```text
 ~/Library/Group Containers/group.com.apple.reminders/Container_v1/Stores/Data-*.sqlite
 ```
+
+See [Multi-Account Support](#multi-account-support) for how RemCTL selects among
+and reads across these stores.
 
 This exposes fields EventKit does not expose cleanly for fast list views:
 
@@ -161,6 +165,92 @@ remctl permissions full-disk-access
 
 The helper opens the Full Disk Access pane, copies the first path to the clipboard, exposes each target as a draggable file row, and periodically checks whether each target can read the Reminders store. Verified targets get a green check. It does not edit macOS TCC data directly.
 
+## Multi-Account Support
+
+macOS Reminders stores each account — iCloud, Exchange, CalDAV, and on-device
+local — in a separate `Data-<uuid>.sqlite` file under the Stores directory.
+RemCTL reads the account name and type directly from each store's CoreData
+metadata so that accounts are identified by the display name Reminders.app
+shows, not by a UUID or file path.
+
+**Account discovery**
+
+`discover_accounts()` (remctl:~280) scans the Stores directory and returns all
+real accounts in descending order by reminder count. Each `Account` namedtuple
+carries `store_path`, `name`, and `type`. The account type is derived from
+`ZREMCDREPLICAMANAGER.ZIDENTIFIER` suffixes:
+
+| Identifier suffix | Type |
+| --- | --- |
+| `com.apple.exchangesync.exchangesyncd` | Exchange |
+| `com.apple.reminders` | iCloud |
+| (none or other) | Local |
+
+Accounts named `LocalInternal` and stores that contain no reminders are
+excluded automatically. The first element of the returned list is always the
+same store that the existing `find_main_db_path()` would have selected, so
+the default single-account behavior is unchanged.
+
+**Default database selection**
+
+`find_main_db_path()` (remctl:~226) picks the store with the most reminder
+rows, using the most-recent file-group modification time (`.sqlite`, `-wal`,
+and `-shm` files) as a tiebreak. This correctly identifies the active iCloud
+store even when a larger but less active Exchange store is present.
+
+**Account scope in commands**
+
+Read commands (`lists`, `show`, `today`, `flagged`, `urgent`, `upcoming`,
+`overdue`, `search`) accept `--all-accounts` and `--account NAME`. Write
+commands (`add`, `done`, `undone`, `edit`, `delete`, `flag`, `unflag`) accept
+`--account NAME` to target a reminder or list in a specific account when the
+same integer ID (`Z_PK`) exists in more than one store.
+
+Account flags are accepted both before and after the subcommand (the launcher
+skips them when identifying the command), so `remctl --account X today` and
+`remctl today --account X` are equivalent.
+
+`resolve_account_scope()` resolves the active scope from, in priority order:
+`--account`/`--all-accounts` flags, the `REMCTL_ACCOUNT_SCOPE` environment
+variable, the `accountScope` key in `~/.config/remctl/config.json`, and the
+single-account default. When the scope resolves to exactly one account, all
+output is byte-identical to the pre-multi-account behavior — no account labels,
+no extra columns.
+
+**Z_PK collision safety**
+
+`Z_PK` row identifiers are local to each store and are not unique across
+accounts. RemCTL never mixes rows from different stores into a single query
+or join. The `iter_account_dbs()` context manager opens one connection per
+account and keeps them separate through serialization; account metadata is
+stamped onto already-serialized dicts, not injected into SQL queries.
+
+For single-item commands, `_resolve_reminder_for_write()` honors the active
+scope: with one account it reads that store directly; across multiple accounts
+it scans each store for the requested ID, acts on a unique match, and reports an
+ambiguity error when the ID exists in more than one. `resolve_list_ref_across()`
+and `resolve_reminder_across()` provide the same scan-and-disambiguate logic for
+list and reminder references. All three stamp the resolved account back onto the
+request so the write path targets the correct store.
+
+**Writes to non-CloudKit accounts**
+
+The EventKit bridge enumerates calendars from every account, so writes are not
+limited to iCloud. iCloud reminders carry a CloudKit identifier
+(`ZCKIDENTIFIER`) that RemCTL passes straight to the bridge. Exchange and other
+CalDAV reminders do not store that identifier, so `_ek_identifier()` resolves a
+stable EventKit `calendarItemIdentifier` on demand: it asks the bridge
+(`list_calendars`) for the target calendar, then (`find_reminder`) for the
+reminder by title within that calendar. New reminders are likewise created
+against a resolved `calendarIdentifier` rather than a list name, which keeps
+same-named lists in different accounts unambiguous. Because non-iCloud
+reminders have no CloudKit identifier, the numeric ID of a freshly created
+Exchange reminder is recovered by title immediately after creation.
+
+The config file additionally accepts `storeDir` and `dbPath` keys, the
+persistent equivalents of `REMCTL_STORE_DIR` and `REMCTL_DB`; environment
+variables take precedence over the config file.
+
 ## Environment Overrides
 
 ```bash
@@ -168,7 +258,10 @@ REMCTL_BRIDGE_PATH=/path/to/remctl-bridge
 REMCTL_PRIVATE_PATH=/path/to/remctl-private
 REMCTL_PERMISSIONS_PATH=/path/to/remctl-permissions
 REMCTL_PATH=/path/to/remctl
-REMCTL_STORE_DIR=/path/to/reminders/store
+REMCTL_STORE_DIR=/path/to/reminders/store   # override the whole Stores directory
+REMCTL_DB=/path/to/Data-XXXX.sqlite         # pin a specific database file (bypasses auto-detection)
+REMCTL_ACCOUNT_SCOPE=all                    # equivalent to --all-accounts for every command
+REMCTL_ACCOUNT_SCOPE=iCloud                 # restrict to a named account globally
 REMCTL_CONFIG_DIR=/path/to/config
 NO_COLOR=1
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,6 +2,107 @@
 
 Run `remctl --help` for the full parser-generated reference and `remctl <command> --help` for command-specific options.
 
+## Multi-Account
+
+RemCTL supports multiple Reminders accounts — iCloud, Exchange, and on-device local — simultaneously. Each account is stored in a separate database file. By default, RemCTL reads from and writes to the account with the most reminders; all existing behavior is unchanged when only one account is active.
+
+### Discovering accounts
+
+```bash
+remctl accounts          # list all connected accounts with their type and default status
+remctl accounts --json   # machine-readable output
+```
+
+### Reading across accounts
+
+Pass `--all-accounts` to any read command to include all connected accounts (`export` and `import` are the exception — see below). Pass `--account NAME` to restrict the scope to a single named account.
+
+```bash
+remctl lists --all-accounts
+remctl today --all-accounts
+remctl flagged --all-accounts
+remctl search "meeting" --all-accounts
+remctl tags --all-accounts
+remctl sections --all-accounts
+remctl stats --all-accounts
+remctl show --list-id 1 --account Exchange
+remctl show Tasks --account Exchange
+```
+
+When multiple accounts are active, human output groups results under a bold account name header. JSON output includes `account` and `accountType` fields on each item. The table format adds an Account column. `tags` returns the deduplicated union across accounts; `stats --all-accounts` prints a per-account breakdown followed by a combined total.
+
+`export` and `import` are the exception: they operate on a single account. Both accept `--account NAME`, but not `--all-accounts`. Because reminder IDs are unique only within an account, an all-account dump would carry colliding IDs; to avoid a backup that silently spans accounts, `export` refuses any `all`-scope (whether from `accountScope` or the environment) and exits with an error directing you to pass `--account NAME`. Export each account separately to back up everything.
+
+### Writing to a specific account
+
+Pass `--account NAME` to any write command to target a reminder or list in a specific account.
+
+```bash
+remctl add "Send invoice" -l Work --account Exchange
+remctl done 23 --account Exchange
+remctl edit 23 --title "Updated title" --account Exchange
+remctl delete 23 --force --account Exchange
+remctl flag 23 --account iCloud
+```
+
+Reminder IDs (`Z_PK`) are unique only within a single account. When the active scope spans more than one account — because `--all-accounts` is in effect or `accountScope` is set to `all` — RemCTL resolves a bare `done 23` / `edit 23` / `info 23` by searching every active account: a unique match is acted on automatically, while an ID or list name present in multiple accounts produces a disambiguation error listing the candidates and requires `--account`. In the default single-account scope, IDs resolve against that account exactly as before.
+
+> **Note on non-iCloud accounts.** Exchange and other CalDAV accounts do not store the CloudKit identifier that iCloud reminders carry. RemCTL resolves a stable EventKit identifier for these reminders through the bridge so that create, edit, complete, and delete work normally and sync to the server. Two features are iCloud/on-device only and are unavailable for Exchange/CalDAV reminders: **flagging** (`flag`/`unflag` — those accounts have no flag attribute; use priority instead) and **deep links** (`link` reports no link, and `open` falls back to launching Reminders.app). To Do "Important (starred)" tasks come through as priority, not flags — see [Flags, Priorities, Urgent, and Recurrence](#flags-priorities-urgent-and-recurrence).
+>
+> **Exchange sync is not instant.** Unlike iCloud (which pushes through CloudKit immediately), Exchange/CalDAV changes are uploaded by macOS on a short sync cycle, so a `done`/`add`/`edit`/`delete` may take a minute or two to appear on the server. The change applies locally right away; if you check the server immediately and don't see it yet, give the sync cycle time rather than re-issuing the command.
+
+### Setting a default account scope
+
+The default scope (single account) can be overridden persistently via the config file or an environment variable:
+
+```bash
+remctl config accountScope all      # show all accounts by default for every command
+remctl config accountScope Exchange # restrict all commands to Exchange by default
+remctl config accountScope          # show the current setting
+```
+
+```bash
+REMCTL_ACCOUNT_SCOPE=all remctl today    # one-shot override via environment variable
+```
+
+### Configuration
+
+```bash
+remctl config                        # show all current settings
+remctl config --help                 # list every supported key and its meaning
+remctl config accountScope           # get a single setting
+remctl config accountScope all       # set a setting
+remctl config accountScope ""        # clear a setting (restore the default)
+```
+
+The configuration file is stored at `~/.config/remctl/config.json` and can be edited directly. Three keys are recognized:
+
+| Key | Purpose | Equivalent environment variable |
+|-----|---------|----------------------------------|
+| `accountScope` | Default account scope: `all`, an account name, or `""` for the auto-detected default | `REMCTL_ACCOUNT_SCOPE` |
+| `storeDir` | Override the Reminders Stores directory | `REMCTL_STORE_DIR` |
+| `dbPath` | Pin a specific database file (full path); bypasses auto-detection | `REMCTL_DB` |
+
+Setting a key to an empty string removes it. Environment variables always take precedence over the config file. `dbPath` pins one exact `.sqlite` file and overrides `storeDir`; use `storeDir` to point auto-detection at a non-standard Stores directory while still selecting among the accounts it contains.
+
+```bash
+remctl config storeDir "/Volumes/Backup/Reminders/Stores"   # non-standard location
+remctl config dbPath "/path/to/Data-XXXX.sqlite"            # pin one exact database
+```
+
+### Flag placement
+
+Account flags may be given either before or after the command, so both forms are equivalent:
+
+```bash
+remctl --account Exchange today
+remctl today --account Exchange
+remctl --all-accounts lists
+remctl lists --all-accounts
+```
+
+---
+
 ## Viewing
 
 ```bash
@@ -43,7 +144,8 @@ remctl edit 23880 --recurrence "weekly mon,wed"
 RemCTL keeps these states distinct:
 
 - priority is written with `-p high`, `-p medium`, or `-p low` and shown as `!!!`, `!!`, or `!`
-- flagged reminders are shown with `⚑` and can be changed with `flag` / `unflag`
+- iCloud stores priority as 1 (high), 5 (medium), or 9 (low). Exchange and other CalDAV accounts use the full iCalendar range, where 1–4 is high, 5 is medium, and 6–9 is low; RemCTL buckets these the same way Reminders.app does. A Microsoft To Do task marked **Important (starred)** syncs through Exchange as high importance and appears in Reminders as a high priority (`!!!`), not as a flag
+- flagged reminders are shown with `⚑` and can be changed with `flag` / `unflag`. Flags exist only for iCloud and on-device reminders; Exchange/CalDAV accounts have no flag attribute, so `flag`/`unflag` are unavailable there and report a clear error suggesting priority instead
 - macOS 26 urgent reminders are shown with `⏰` and listed with `urgent`
 - urgent is stored in private ReminderKit metadata; power users can opt into unsupported writes with `add --private --urgent` or `edit --private --urgent`
 - recurring reminders are shown with a `↻` badge and, in table output, a `Repeat` column
@@ -169,6 +271,14 @@ remctl flag 23880
 remctl unflag 23880
 remctl delete 23880
 remctl delete 23880 --force
+```
+
+When the same reminder ID exists in more than one account, pass `--account NAME` to disambiguate:
+
+```bash
+remctl done 23 --account Exchange
+remctl edit 23 -d tomorrow --account iCloud
+remctl delete 23 --force --account Exchange
 ```
 
 ## Lists

--- a/remctl
+++ b/remctl
@@ -6,7 +6,8 @@ attachments, completion status, list colors). Writes via remctl-bridge (EventKit
 with AppleScript fallback. Zero Python dependencies with small shared helpers.
 """
 
-import argparse, base64, csv, html as html_lib, io, json, os, platform, plistlib, re, shlex, shutil, sqlite3, subprocess, sys, tempfile, time, unicodedata, uuid
+import argparse, base64, contextlib, csv, html as html_lib, io, json, os, platform, plistlib, re, shlex, shutil, sqlite3, subprocess, sys, tempfile, time, unicodedata, uuid
+from collections import namedtuple
 from datetime import datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -17,6 +18,7 @@ from remctl_runtime import (
     is_safe_remote_url,
     resolve_binary_path,
     resolve_config_dir,
+    resolve_db_override,
     resolve_store_dir,
     start_of_day,
     upcoming_window,
@@ -48,12 +50,45 @@ VERSION = "1.0.5"
 
 APPLE_EPOCH = 978307200
 STORE_DIR = resolve_store_dir()
+DB_OVERRIDE = resolve_db_override()
 BRIDGE_PATH = resolve_binary_path(__file__, "remctl-bridge", "REMCTL_BRIDGE_PATH")
 PRIVATE_PATH = resolve_binary_path(__file__, "remctl-private", "REMCTL_PRIVATE_PATH")
 PERMISSIONS_PATH = resolve_binary_path(__file__, "remctl-permissions", "REMCTL_PERMISSIONS_PATH")
 CONFIG_DIR = resolve_config_dir("remctl")
 ONBOARD_STATE_FILE = CONFIG_DIR / "onboard-state.json"
+CONFIG_FILE = CONFIG_DIR / "config.json"
 AUTO_ONBOARD_SKIP_ENV = "REMCTL_SKIP_ONBOARD"
+ACCOUNT_SCOPE_ENV = "REMCTL_ACCOUNT_SCOPE"
+
+def _apply_config_path_overrides():
+    """Apply storeDir / dbPath from config.json when env vars are not set.
+
+    Env vars always win; config is a fallback for users who prefer not to
+    set shell variables permanently.
+    """
+    global STORE_DIR, DB_OVERRIDE
+    try:
+        if not CONFIG_FILE.exists():
+            return
+        import json as _json
+        cfg = _json.loads(CONFIG_FILE.read_text())
+        if not isinstance(cfg, dict):
+            return
+        if not os.environ.get("REMCTL_STORE_DIR"):
+            store_dir_val = cfg.get("storeDir", "")
+            if store_dir_val:
+                STORE_DIR = Path(store_dir_val).expanduser()
+        if not os.environ.get("REMCTL_DB"):
+            db_path_val = cfg.get("dbPath", "")
+            if db_path_val:
+                DB_OVERRIDE = Path(db_path_val).expanduser()
+    except Exception:
+        pass
+
+_apply_config_path_overrides()
+HIDDEN_ACCOUNT_NAMES = {"LocalInternal"}
+
+Account = namedtuple("Account", ["store_path", "name", "type"])
 AUTO_ONBOARD_SKIP_COMMANDS = {"completion", "doctor", "onboard", "permissions", "setup"}
 FULL_DISK_ACCESS_SETTINGS_URLS = [
     "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_AllFiles",
@@ -188,11 +223,143 @@ def find_main_db():
     return db_path
 
 
+def _store_file_group_mtime(path):
+    mtimes = [path.stat().st_mtime]
+    for suffix in ("-wal", "-shm"):
+        sidecar = path.with_name(path.name + suffix)
+        if sidecar.exists():
+            mtimes.append(sidecar.stat().st_mtime)
+    return max(mtimes)
+
+
+def _store_reminder_count(path):
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        try:
+            return conn.execute("SELECT COUNT(*) FROM ZREMCDOBJECT").fetchone()[0]
+        finally:
+            conn.close()
+    except Exception:
+        return -1
+
+
 def find_main_db_path():
     if reminders_store_access_error():
         return None
-    candidates = sorted(STORE_DIR.glob("Data-*.sqlite"), key=lambda p: p.stat().st_size, reverse=True)
-    return candidates[0] if candidates else None
+    if DB_OVERRIDE:
+        return DB_OVERRIDE if DB_OVERRIDE.exists() else None
+    candidates = list(STORE_DIR.glob("Data-*.sqlite"))
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+    return max(candidates, key=lambda p: (_store_reminder_count(p), _store_file_group_mtime(p)))
+
+def _store_account_info(path):
+    """Return (name, type) for the account in *path*, or None if unreadable."""
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        try:
+            # Derive the account entity number dynamically — do not hardcode Z_ENT=14
+            ent_row = conn.execute(
+                "SELECT Z_ENT FROM Z_PRIMARYKEY WHERE Z_NAME='REMCDAccount'"
+            ).fetchone()
+            if ent_row is None:
+                return None
+            ent = ent_row[0]
+            name_row = conn.execute(
+                "SELECT ZNAME FROM ZREMCDOBJECT WHERE Z_ENT=? AND ZNAME IS NOT NULL LIMIT 1",
+                (ent,),
+            ).fetchone()
+            # name may be absent on a freshly-added account that hasn't synced yet
+            name = name_row[0] if name_row else None
+
+            # Derive account type from replica manager identifiers
+            acct_type = "Local"
+            try:
+                rows = conn.execute(
+                    "SELECT ZIDENTIFIER FROM ZREMCDREPLICAMANAGER WHERE ZIDENTIFIER IS NOT NULL"
+                ).fetchall()
+                identifiers = [r[0] for r in rows]
+            except Exception:
+                identifiers = []
+            for ident in identifiers:
+                if "exchangesync" in ident:
+                    acct_type = "Exchange"
+                    break
+            else:
+                if any("com.apple.reminders" in i for i in identifiers):
+                    if any("sharingextension" in i for i in identifiers):
+                        acct_type = "iCloud"
+                    elif identifiers:
+                        acct_type = "iCloud"
+
+            # Fall back to a name derived from the replica UUID or the store filename
+            if not name:
+                if identifiers:
+                    # e.g. "338B0300-8139-4FBC-99F1-F90AF04ECEA3/com.apple.exchangesync.exchangesyncd"
+                    # → use the UUID prefix as a temporary identifier
+                    uuid_part = identifiers[0].split("/")[0]
+                    name = f"{acct_type} ({uuid_part[:8]})"
+                else:
+                    name = f"{acct_type} ({path.stem[-8:]})"
+
+            return (name, acct_type)
+        finally:
+            conn.close()
+    except Exception:
+        return None
+
+
+_ACCOUNT_CACHE = None
+
+
+def discover_accounts(*, force_refresh=False):
+    """Return all real (non-hidden, non-empty) Reminders accounts, most-reminders first.
+
+    Each element is an Account(store_path, name, type) namedtuple. The first
+    element is always the same store that find_main_db_path() would return,
+    preserving backward-compat for the default single-account path.
+
+    Results are process-memoized; pass force_refresh=True to re-scan.
+    """
+    global _ACCOUNT_CACHE
+    if _ACCOUNT_CACHE is not None and not force_refresh:
+        return _ACCOUNT_CACHE
+
+    if reminders_store_access_error():
+        _ACCOUNT_CACHE = []
+        return _ACCOUNT_CACHE
+
+    # Honor single-file override
+    if DB_OVERRIDE:
+        if not DB_OVERRIDE.exists():
+            _ACCOUNT_CACHE = []
+            return _ACCOUNT_CACHE
+        info = _store_account_info(DB_OVERRIDE)
+        name = info[0] if info else DB_OVERRIDE.stem
+        acct_type = info[1] if info else "Local"
+        _ACCOUNT_CACHE = [Account(DB_OVERRIDE, name, acct_type)]
+        return _ACCOUNT_CACHE
+
+    candidates = list(STORE_DIR.glob("Data-*.sqlite"))
+    accounts = []
+    for path in candidates:
+        info = _store_account_info(path)
+        if info is None:
+            continue  # unreadable or missing CoreData schema
+        name, acct_type = info
+        if name in HIDDEN_ACCOUNT_NAMES:
+            continue
+        count = _store_reminder_count(path)
+        mtime = _store_file_group_mtime(path)
+        accounts.append((count, mtime, Account(path, name, acct_type)))
+
+    # Sort: most reminders first, then newest mtime (same sort key as find_main_db_path)
+    accounts.sort(key=lambda x: (x[0], x[1]), reverse=True)
+    _ACCOUNT_CACHE = [a for _, _, a in accounts]
+    return _ACCOUNT_CACHE
+
 
 def open_db():
     conn = sqlite3.connect(f"file:{find_main_db()}?mode=ro", uri=True)
@@ -206,8 +373,46 @@ def ts(v):
 def to_ts(dt):
     return dt.timestamp() - APPLE_EPOCH
 
-PRI = {0: "", 1: "!!!", 5: "!!", 9: "!"}
-PRI_NAME = {0: "none", 1: "high", 5: "medium", 9: "low"}
+def priority_bucket(value):
+    """Map a stored priority value to a canonical bucket.
+
+    Apple iCloud reminders only use 1/5/9, but Exchange and other CalDAV
+    accounts store the full iCalendar (RFC 5545) priority range, where
+    1-4 = high, 5 = medium, and 6-9 = low. 0 (or NULL) means no priority.
+    Reminders.app interprets these ranges; RemCTL matches that behavior so a
+    Microsoft To Do "starred" (High importance) task — which can sync as any
+    value in 1-4 — is shown as high rather than dropped.
+    """
+    v = value or 0
+    if v <= 0:
+        return "none"
+    if v <= 4:
+        return "high"
+    if v == 5:
+        return "medium"
+    return "low"  # 6-9 (and any value > 9, defensively)
+
+
+class _PriorityMap(dict):
+    """Range-aware priority lookup keyed by stored value (0-9).
+
+    Behaves like the old exact-value dict for Apple's native 1/5/9, but buckets
+    the full iCalendar range so Exchange/CalDAV values (e.g. 3) resolve too.
+    """
+    def __init__(self, by_bucket):
+        super().__init__({0: by_bucket["none"], 1: by_bucket["high"],
+                          5: by_bucket["medium"], 9: by_bucket["low"]})
+        self._by_bucket = by_bucket
+
+    def get(self, key, default=None):
+        return self._by_bucket.get(priority_bucket(key), default if default is not None else self._by_bucket["none"])
+
+    def __getitem__(self, key):
+        return self.get(key)
+
+
+PRI = _PriorityMap({"none": "", "high": "!!!", "medium": "!!", "low": "!"})
+PRI_NAME = _PriorityMap({"none": "none", "high": "high", "medium": "medium", "low": "low"})
 
 # ── List Color Parsing ───────────────────────────────────────────────────────
 
@@ -404,14 +609,14 @@ def load_list_colors(db):
         pass
     return colors
 
-# Global list color cache — populated on demand
-_list_colors = None
+# Per-connection list color cache keyed by connection id()
+_list_colors_cache = {}
 
 def get_list_colors(db):
-    global _list_colors
-    if _list_colors is None:
-        _list_colors = load_list_colors(db)
-    return _list_colors
+    key = id(db)
+    if key not in _list_colors_cache:
+        _list_colors_cache[key] = load_list_colors(db)
+    return _list_colors_cache[key]
 
 def color_list_name(name, db=None):
     """Return the list name colored by its Reminders color."""
@@ -736,7 +941,7 @@ def grocery_list_payload(row):
     return payload
 
 
-def list_to_dict(row):
+def list_to_dict(row, *, account=None):
     is_groceries = is_grocery_list_row(row)
     item = {
         "id": _row_value(row, "Z_PK"),
@@ -744,6 +949,9 @@ def list_to_dict(row):
         "listType": "groceries" if is_groceries else "standard",
         "isGroceries": is_groceries,
     }
+    if account is not None:
+        item["account"] = account.name
+        item["accountType"] = account.type
     object_uuid = _row_value(row, "ZCKIDENTIFIER")
     if object_uuid:
         item["objectUUID"] = object_uuid
@@ -786,7 +994,7 @@ def normalize_list_lookup_name(name):
                     last_space = True
     return "".join(parts).strip()
 
-def list_ref_payload(row, *, requested=None, method="exact"):
+def list_ref_payload(row, *, requested=None, method="exact", account=None):
     payload = {
         "id": _row_value(row, "Z_PK"),
         "title": _row_value(row, "ZNAME"),
@@ -794,6 +1002,9 @@ def list_ref_payload(row, *, requested=None, method="exact"):
         "requested": requested,
         "method": method,
     }
+    if account is not None:
+        payload["account"] = account.name
+        payload["accountType"] = account.type
     payload["isGroceries"] = is_grocery_list_row(row)
     grocery = grocery_list_payload(row)
     if grocery and (payload["isGroceries"] or any(grocery.values())):
@@ -996,16 +1207,106 @@ def resolve_list_ref(db, name=None, list_id=None):
 
 def _print_list_resolution_error(requested, result=None):
     if result and result.get("error") == "ambiguous":
+        candidates = result.get("candidates", [])
         options = ", ".join(
-            f"{candidate['id']} ({candidate['title']})"
-            for candidate in result.get("candidates", [])
+            (f"{c.get('account', '')}/{c['id']} ({c['title']})"
+             if c.get("account") else f"{c['id']} ({c['title']})")
+            for c in candidates
         )
+        hint = " Use --account to specify the account." if any(c.get("account") for c in candidates) else ""
         print(
-            f"Error: multiple lists match {requested!r}. Use the exact list name or --list-id with one of: {options}",
+            f"Error: multiple lists match {requested!r}. Use the exact list name or --list-id with one of: {options}{hint}",
             file=sys.stderr,
         )
     else:
         print(f"Error: list not found: {requested}", file=sys.stderr)
+
+
+def resolve_list_ref_across(account_dbs, *, name=None, list_id=None, account_name=None):
+    """Resolve a list reference across multiple account connections.
+
+    When *account_name* is given, resolution is limited to that one account
+    (exactly as today's single-account resolve_list_ref, plus stamping account).
+    When *account_dbs* has only one entry, behaviour is identical to the
+    single-account path (back-compat).
+
+    Returns a list_ref_payload dict on success (with an 'account' field when
+    multi-account), an ambiguity dict when the reference matches in multiple
+    accounts, or None when not found.
+    """
+    multi = len(account_dbs) > 1
+
+    # Filter to a specific account if requested
+    if account_name:
+        lower = account_name.lower()
+        target = [(acct, db) for acct, db in account_dbs if acct.name.lower() == lower]
+        if not target:
+            print(f"Error: account {account_name!r} not found or not active.", file=sys.stderr)
+            sys.exit(1)
+        acct, db = target[0]
+        result = resolve_list_ref(db, name=name, list_id=list_id)
+        if result and not result.get("error"):
+            result["account"] = acct.name
+            result["accountType"] = acct.type
+            result["_store_path"] = str(acct.store_path)
+        return result
+
+    # Scan all active accounts
+    hits = []
+    for acct, db in account_dbs:
+        result = resolve_list_ref(db, name=name, list_id=list_id)
+        if result and not result.get("error"):
+            result["_store_path"] = str(acct.store_path)
+            if multi:
+                result["account"] = acct.name
+                result["accountType"] = acct.type
+            hits.append(result)
+
+    if not hits:
+        return None
+    if len(hits) == 1:
+        return hits[0]
+    # Multiple accounts matched — return ambiguity payload
+    return {"error": "ambiguous", "requested": name or str(list_id), "candidates": hits}
+
+
+def resolve_reminder_across(account_dbs, pk, *, account_name=None):
+    """Resolve a reminder by integer Z_PK across multiple account connections.
+
+    Returns (Account, sqlite3.Connection, row) on success, None if not found.
+    Calls sys.exit on ambiguity (same Z_PK found in multiple active accounts).
+
+    For UUID-based lookups use q_reminder_by_identifier directly — UUIDs are
+    globally unique and need no cross-account disambiguation.
+    """
+    if account_name:
+        lower = account_name.lower()
+        target = [(acct, db) for acct, db in account_dbs if acct.name.lower() == lower]
+        if not target:
+            print(f"Error: account {account_name!r} not found or not active.", file=sys.stderr)
+            sys.exit(1)
+        acct, db = target[0]
+        row = q_reminder(db, pk)
+        return (acct, db, row) if row else None
+
+    hits = []
+    for acct, db in account_dbs:
+        row = q_reminder(db, pk)
+        if row:
+            hits.append((acct, db, row))
+
+    if not hits:
+        return None
+    if len(hits) == 1:
+        return hits[0]
+    # Ambiguous — same Z_PK in multiple accounts
+    accounts_str = ", ".join(h[0].name for h in hits)
+    print(
+        f"Error: reminder id {pk} exists in multiple accounts ({accounts_str}). "
+        "Use --account to specify which one.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 def resolve_list_or_die(db, name=None, list_id=None):
     result = resolve_list_ref(db, name=name, list_id=list_id)
@@ -1257,6 +1558,43 @@ def resolve_required_template_target_or_die(db, *, name=None, template_id=None):
     requested = f"id {template_id}" if template_id is not None else name
     _print_template_resolution_error(requested, result)
     sys.exit(1)
+
+
+def resolve_template_ref_across(account_dbs, *, name=None, template_id=None, account_name=None):
+    """Resolve a template reference across multiple account connections.
+
+    Mirrors resolve_list_ref_across: stamps '_store_path' (and account/accountType
+    when multi-account), returns an ambiguity dict when matched in multiple
+    accounts, or None when not found.
+    """
+    multi = len(account_dbs) > 1
+    if account_name:
+        lower = account_name.lower()
+        target = [(acct, db) for acct, db in account_dbs if acct.name.lower() == lower]
+        if not target:
+            print(f"Error: account {account_name!r} not found or not active.", file=sys.stderr)
+            sys.exit(1)
+        acct, db = target[0]
+        result = resolve_template_ref(db, name=name, template_id=template_id)
+        if result and not result.get("error"):
+            result["account"] = acct.name
+            result["accountType"] = acct.type
+            result["_store_path"] = str(acct.store_path)
+        return result
+    hits = []
+    for acct, db in account_dbs:
+        result = resolve_template_ref(db, name=name, template_id=template_id)
+        if result and not result.get("error"):
+            result["_store_path"] = str(acct.store_path)
+            if multi:
+                result["account"] = acct.name
+                result["accountType"] = acct.type
+            hits.append(result)
+    if not hits:
+        return None
+    if len(hits) == 1:
+        return hits[0]
+    return {"error": "ambiguous", "requested": name or str(template_id), "candidates": hits}
 
 
 def _template_time(row, key):
@@ -1887,12 +2225,13 @@ def preload_extras(db, pks):
     return shared_preload_extras(db, pks)
 
 def _color_priority(pri_val):
-    """Color a priority marker based on level."""
+    """Color a priority marker based on level (range-aware for Exchange/CalDAV)."""
     p = PRI.get(pri_val or 0, "")
     if not p: return ""
-    if pri_val == 1: return C.red(p)
-    if pri_val == 5: return C.yellow(p)
-    if pri_val == 9: return C.green(p)
+    bucket = priority_bucket(pri_val)
+    if bucket == "high": return C.red(p)
+    if bucket == "medium": return C.yellow(p)
+    if bucket == "low": return C.green(p)
     return p
 
 
@@ -2155,6 +2494,63 @@ def reminders_to_dicts(items, db=None, memberships=None):
                     payload["assignment"] = assignment
     return payloads
 
+def _tag_account(payload, account, multi):
+    """Stamp account metadata onto *payload* when in multi-account mode."""
+    if multi:
+        payload["account"] = account.name
+        payload["accountType"] = account.type
+    return payload
+
+
+def gather_reminder_dicts(scope, query_fn, *,
+                          memberships_fn=None, section=None):
+    """Execute *query_fn(db)* against each account in *scope*, serialize
+    per-connection (preserving Z_PK-scoped joins), and return a merged list
+    of dicts, each tagged with 'account'/'accountType' when multi-account.
+
+    *query_fn* must be a callable that takes a single sqlite3.Connection and
+    returns a list of reminder rows from that store.
+
+    *memberships_fn(db, list_pk)* is optional — used by show/section commands.
+    """
+    multi = len(scope) > 1
+    results = []
+    with iter_account_dbs(scope) as account_dbs:
+        for acct, db in account_dbs:
+            rows = query_fn(db)
+            if not rows:
+                continue
+            pks = [r["Z_PK"] for r in rows]
+            sc, ht = preload_extras(db, pks)
+            memberships = memberships_fn(db) if memberships_fn else None
+            for r in rows:
+                s = section
+                if memberships is not None:
+                    s = memberships.get(r["Z_PK"])
+                payload = to_dict(r, db=db, section=s, _sc=sc, _ht=ht)
+                _tag_account(payload, acct, multi)
+                results.append(payload)
+    return results
+
+
+def gather_table_rows(scope, query_fn):
+    """Like gather_reminder_dicts but produces fmt_table-shaped rows, preserving
+    the rich id/title/due/repeat/pri formatting that reminders_to_table_data
+    builds. An 'account' column is added only when more than one account is
+    active, so single-account table output is byte-identical to the original.
+    """
+    multi = len(scope) > 1
+    rows = []
+    with iter_account_dbs(scope) as account_dbs:
+        for acct, db in account_dbs:
+            items = query_fn(db)
+            for row in reminders_to_table_data(items, db):
+                if multi:
+                    row["account"] = acct.name
+                rows.append(row)
+    return rows
+
+
 # ── Table Format ─────────────────────────────────────────────────────────────
 
 def _strip_ansi(s):
@@ -2184,6 +2580,8 @@ def fmt_table(rows_data, max_width=None):
             max_width = 80
 
     columns = [("id", "ID"), ("title", "Title"), ("list", "List"), ("due", "Due")]
+    if any(row.get("account") for row in rows_data):
+        columns.append(("account", "Account"))
     if any(row.get("repeat") for row in rows_data):
         columns.append(("repeat", "Repeat"))
     columns.append(("pri", "Pri"))
@@ -2312,9 +2710,9 @@ def bridge_call_result(data, timeout=30):
     }
 
 def bridge_call(data):
-    """Call remctl-bridge with JSON data. Returns parsed JSON response."""
+    """Call remctl-bridge with JSON data. Returns parsed JSON response (dict or list)."""
     result = bridge_call_result(data)
-    if result and result["returncode"] == 0 and isinstance(result["payload"], dict):
+    if result and result["returncode"] == 0 and result["payload"] is not None:
         return result["payload"]
     return None
 
@@ -3820,6 +4218,116 @@ def write_onboard_state(result, *, auto=False):
     }, indent=2) + "\n")
 
 
+def load_config():
+    """Return the user's remctl config dict, or {} on missing/invalid."""
+    if not CONFIG_FILE.exists():
+        return {}
+    try:
+        data = json.loads(CONFIG_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_config(data):
+    """Persist *data* to the remctl config file."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def resolve_account_scope(a):
+    """Return the list of Account objects to use for the current command.
+
+    Precedence (highest first):
+      1. --account NAME (repeatable flag; case-insensitive)
+      2. --all-accounts flag
+      3. REMCTL_ACCOUNT_SCOPE env var ("all" or an account name)
+      4. config.json accountScope key ("all" or an account name)
+      5. default: [discover_accounts()[0]]  (single-account, back-compat)
+    """
+    all_accounts = discover_accounts()
+    if not all_accounts:
+        return []
+
+    def _filter_by_name(names):
+        lower = [n.lower() for n in names]
+        matched = [a for a in all_accounts if a.name.lower() in lower]
+        missing = [n for n in names if not any(a.name.lower() == n.lower() for a in all_accounts)]
+        if missing:
+            print(f"Error: Unknown account(s): {', '.join(missing)}. "
+                  f"Available: {', '.join(a.name for a in all_accounts)}", file=sys.stderr)
+            sys.exit(1)
+        return matched
+
+    # 1. --account flag (string from acct(c) or list from account_scope(c))
+    account_flags = getattr(a, "account", None)
+    if account_flags:
+        if isinstance(account_flags, str):
+            account_flags = [account_flags]
+        return _filter_by_name(account_flags)
+
+    # 2. --all-accounts flag
+    if getattr(a, "all_accounts", False):
+        return all_accounts
+
+    # 3. Env override
+    env_scope = os.environ.get(ACCOUNT_SCOPE_ENV, "").strip()
+    if env_scope:
+        if env_scope.lower() == "all":
+            return all_accounts
+        return _filter_by_name([env_scope])
+
+    # 4. Config file
+    cfg_scope = load_config().get("accountScope", "")
+    if cfg_scope:
+        if cfg_scope.lower() == "all":
+            return all_accounts
+        return _filter_by_name([cfg_scope])
+
+    # 5. Default: single-account (back-compat)
+    return [all_accounts[0]]
+
+
+def _is_multi_account_mode(a):
+    """Return True when the caller explicitly requested multi-account output.
+
+    Single-account mode (the default) falls through to the existing open_db()
+    path so that mocking remains simple in tests.
+    """
+    if getattr(a, "all_accounts", False):
+        return True
+    if getattr(a, "account", None):
+        return True
+    if os.environ.get(ACCOUNT_SCOPE_ENV, "").strip():
+        return True
+    if load_config().get("accountScope", ""):
+        return True
+    return False
+
+
+@contextlib.contextmanager
+def iter_account_dbs(scope):
+    """Context manager yielding (Account, sqlite3.Connection) for each active account.
+
+    Connections are read-only (mode=ro) and closed on exit, even if an
+    exception occurs.  When scope has one entry the single connection is
+    yielded exactly like open_db() does today.
+    """
+    conns = []
+    try:
+        for acct in scope:
+            conn = sqlite3.connect(f"file:{acct.store_path}?mode=ro", uri=True)
+            conn.row_factory = sqlite3.Row
+            conns.append((acct, conn))
+        yield conns
+    finally:
+        for _, conn in conns:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
 def open_reminders_app_for_onboarding():
     try:
         proc = subprocess.run(
@@ -4510,60 +5018,155 @@ def smart_list_to_dict(row):
         payload["filterError"] = decoded["error"]
     return payload
 
+def _render_smart_list_item(item):
+    kind = item["kind"]
+    smart_type = item["smartListType"] or "(none)"
+    length = item["filterLength"]
+    summary = item.get("filter", {})
+    desc = safe_display(summary.get("description") or "No filter data")
+    if summary and not summary.get("supported", True):
+        desc = f"{desc}: {safe_display(', '.join(summary.get('keys', [])) or 'unknown keys')}"
+    id_details = C.dim(f"(id: {item['id']}, {kind})")
+    pin_info = C.dim(" [pinned]") if item.get("pinned") else ""
+    print(f"  {safe_display(item['name'])} {id_details}{pin_info}")
+    print(f"    {smart_type} · filter bytes: {length} · {desc}")
+
+
 def cmd_smart_lists(a):
-    db = open_db()
-    rows = q_smart_lists(db)
-    payload = [smart_list_to_dict(row) for row in rows]
-    if a.json:
-        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    if not _is_multi_account_mode(a):
+        db = open_db()
+        payload = [smart_list_to_dict(row) for row in q_smart_lists(db)]
+        if a.json:
+            print(json.dumps(payload, indent=2, ensure_ascii=False))
+            return
+        if not payload:
+            print("No smart lists")
+            return
+        print(C.bold("Smart Lists:"))
+        for item in payload:
+            _render_smart_list_item(item)
+        print(f"\n{len(payload)} smart list{'s' if len(payload) != 1 else ''}")
         return
-    if not payload:
-        print("No smart lists")
-        return
-    print(C.bold("Smart Lists:"))
-    for item in payload:
-        kind = item["kind"]
-        smart_type = item["smartListType"] or "(none)"
-        length = item["filterLength"]
-        summary = item.get("filter", {})
-        desc = safe_display(summary.get("description") or "No filter data")
-        if summary and not summary.get("supported", True):
-            desc = f"{desc}: {safe_display(', '.join(summary.get('keys', [])) or 'unknown keys')}"
-        id_details = C.dim(f"(id: {item['id']}, {kind})")
-        pin_info = C.dim(" [pinned]") if item.get("pinned") else ""
-        print(f"  {safe_display(item['name'])} {id_details}{pin_info}")
-        print(f"    {smart_type} · filter bytes: {length} · {desc}")
-    print(f"\n{len(payload)} smart list{'s' if len(payload) != 1 else ''}")
+
+    scope = resolve_account_scope(a)
+    multi = len(scope) > 1
+    with iter_account_dbs(scope) as account_dbs:
+        if a.json:
+            out = []
+            for acct, db in account_dbs:
+                for row in q_smart_lists(db):
+                    d = smart_list_to_dict(row)
+                    if multi:
+                        d["account"] = acct.name
+                        d["accountType"] = acct.type
+                    out.append(d)
+            print(json.dumps(out, indent=2, ensure_ascii=False))
+            return
+        total = 0
+        first = True
+        for acct, db in account_dbs:
+            payload = [smart_list_to_dict(row) for row in q_smart_lists(db)]
+            if not payload:
+                continue
+            if multi:
+                if not first:
+                    print()
+                print(C.bold(f"  {acct.name}"))
+            elif first:
+                print(C.bold("Smart Lists:"))
+            first = False
+            for item in payload:
+                _render_smart_list_item(item)
+            total += len(payload)
+        if total == 0:
+            print("No smart lists")
+            return
+        print(f"\n{total} smart list{'s' if total != 1 else ''}")
+
+
+def _render_template_item(item):
+    bits = [f"id: {item['id']}", f"{item['itemCount']} item{'s' if item['itemCount'] != 1 else ''}"]
+    if item.get("sectionCount"):
+        bits.append(f"{item['sectionCount']} section{'s' if item['sectionCount'] != 1 else ''}")
+    if item.get("publicLink"):
+        bits.append("shared")
+    print(f"  {safe_display(item['name'])} {C.dim('(' + ', '.join(bits) + ')')}")
 
 
 def cmd_templates(a):
-    db = open_db()
-    rows = q_templates(db)
-    payload = [template_to_dict(row) for row in rows]
-    if a.json:
-        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    if not _is_multi_account_mode(a):
+        db = open_db()
+        payload = [template_to_dict(row) for row in q_templates(db)]
+        if a.json:
+            print(json.dumps(payload, indent=2, ensure_ascii=False))
+            return
+        if not payload:
+            print("No templates")
+            return
+        print(C.bold("Templates:"))
+        for item in payload:
+            _render_template_item(item)
+        print(f"\n{len(payload)} template{'s' if len(payload) != 1 else ''}")
         return
-    if not payload:
-        print("No templates")
-        return
-    print(C.bold("Templates:"))
-    for item in payload:
-        bits = [f"id: {item['id']}", f"{item['itemCount']} item{'s' if item['itemCount'] != 1 else ''}"]
-        if item.get("sectionCount"):
-            bits.append(f"{item['sectionCount']} section{'s' if item['sectionCount'] != 1 else ''}")
-        if item.get("publicLink"):
-            bits.append("shared")
-        print(f"  {safe_display(item['name'])} {C.dim('(' + ', '.join(bits) + ')')}")
-    print(f"\n{len(payload)} template{'s' if len(payload) != 1 else ''}")
+
+    scope = resolve_account_scope(a)
+    multi = len(scope) > 1
+    with iter_account_dbs(scope) as account_dbs:
+        if a.json:
+            out = []
+            for acct, db in account_dbs:
+                for row in q_templates(db):
+                    d = template_to_dict(row)
+                    if multi:
+                        d["account"] = acct.name
+                        d["accountType"] = acct.type
+                    out.append(d)
+            print(json.dumps(out, indent=2, ensure_ascii=False))
+            return
+        total = 0
+        first = True
+        for acct, db in account_dbs:
+            payload = [template_to_dict(row) for row in q_templates(db)]
+            if not payload:
+                continue
+            if multi:
+                if not first:
+                    print()
+                print(C.bold(f"  {acct.name}"))
+            elif first:
+                print(C.bold("Templates:"))
+            first = False
+            for item in payload:
+                _render_template_item(item)
+            total += len(payload)
+        if total == 0:
+            print("No templates")
+            return
+        print(f"\n{total} template{'s' if total != 1 else ''}")
 
 
 def cmd_template_info(a):
-    db = open_db()
-    ref = resolve_required_template_target_or_die(
-        db,
-        name=getattr(a, "name", None),
-        template_id=getattr(a, "template_id", None),
-    )
+    name = getattr(a, "name", None)
+    tid = getattr(a, "template_id", None)
+    account_name = getattr(a, "account", None)
+    if _is_multi_account_mode(a):
+        if name and tid is not None:
+            print("Error: pass either a template name or --template-id, not both.", file=sys.stderr)
+            sys.exit(1)
+        if not name and tid is None:
+            print("Error: pass a template name or --template-id.", file=sys.stderr)
+            sys.exit(1)
+        scope = resolve_account_scope(a)
+        with iter_account_dbs(scope) as account_dbs:
+            ref = resolve_template_ref_across(account_dbs, name=name, template_id=tid, account_name=account_name)
+        if not ref or ref.get("error") == "ambiguous":
+            _print_template_resolution_error(name if name else f"id {tid}", ref)
+            sys.exit(1)
+        db = sqlite3.connect(f"file:{Path(ref['_store_path'])}?mode=ro", uri=True)
+        db.row_factory = sqlite3.Row
+    else:
+        db = open_db()
+        ref = resolve_required_template_target_or_die(db, name=name, template_id=tid)
     row = q_template_matches(db, template_id=ref["id"])[0]
     payload = template_to_dict(row, db, include_items=True)
     if a.json:
@@ -5041,25 +5644,74 @@ def cmd_smart_list_delete(a):
         print(f"Deleted smart list: {safe_display(name)}")
 
 def cmd_lists(a):
-    db = open_db()
-    rows = q_lists(db)
-    if a.json:
-        print(json.dumps([list_to_dict(r) for r in rows], indent=2, ensure_ascii=False))
+    if not _is_multi_account_mode(a):
+        # Single-account fast path — back-compat with existing open_db() mocks
+        db = open_db()
+        rows = q_lists(db)
+        if a.json:
+            print(json.dumps([list_to_dict(r) for r in rows], indent=2, ensure_ascii=False))
+            return
+        if getattr(a, 'format', None) == 'table':
+            data = [{"id": r["Z_PK"], "title": format_list_title(r, color=False),
+                     "list": "", "due": "", "pri": ""} for r in rows]
+            print(fmt_table(data))
+            return
+        print(C.bold("Reminder Lists:"))
+        for r in rows:
+            secs = q_sections(db, r["Z_PK"])
+            list_name = format_list_title(r, db)
+            sec_info = C.dim(f" [{len(secs)} sections]") if secs else ""
+            pin_info = C.dim(" [pinned]") if _row_has_key(r, "ZISPINNEDBYCURRENTUSER") and r["ZISPINNEDBYCURRENTUSER"] else ""
+            id_dim = C.dim(f"(id: {r['Z_PK']})")
+            print(f"  {list_name} {id_dim}{sec_info}{pin_info}")
+        print(f"\n{len(rows)} list{'s' if len(rows) != 1 else ''}")
         return
-    if getattr(a, 'format', None) == 'table':
-        data = [{"id": r["Z_PK"], "title": format_list_title(r, color=False),
-                 "list": "", "due": "", "pri": ""} for r in rows]
-        print(fmt_table(data))
-        return
-    print(C.bold("Reminder Lists:"))
-    for r in rows:
-        secs = q_sections(db, r["Z_PK"])
-        list_name = format_list_title(r, db)
-        sec_info = C.dim(f" [{len(secs)} sections]") if secs else ""
-        pin_info = C.dim(" [pinned]") if _row_has_key(r, "ZISPINNEDBYCURRENTUSER") and r["ZISPINNEDBYCURRENTUSER"] else ""
-        id_dim = C.dim(f"(id: {r['Z_PK']})")
-        print(f"  {list_name} {id_dim}{sec_info}{pin_info}")
-    print(f"\n{len(rows)} list{'s' if len(rows) != 1 else ''}")
+
+    # Multi-account path
+    scope = resolve_account_scope(a)
+    multi = len(scope) > 1
+    with iter_account_dbs(scope) as account_dbs:
+        if a.json:
+            all_dicts = []
+            for acct, db in account_dbs:
+                acct_arg = acct if multi else None
+                all_dicts.extend(list_to_dict(r, account=acct_arg) for r in q_lists(db))
+            print(json.dumps(all_dicts, indent=2, ensure_ascii=False))
+            return
+        if getattr(a, 'format', None) == 'table':
+            table_rows = []
+            for acct, db in account_dbs:
+                for r in q_lists(db):
+                    row = {"id": r["Z_PK"], "title": format_list_title(r, color=False),
+                           "list": "", "due": "", "pri": ""}
+                    if multi:
+                        row["account"] = acct.name
+                    table_rows.append(row)
+            print(fmt_table(table_rows))
+            return
+        total = 0
+        first = True
+        for acct, db in account_dbs:
+            rows = q_lists(db)
+            if not rows:
+                continue
+            if multi:
+                if not first:
+                    print()
+                print(C.bold(f"  {acct.name}"))
+                first = False
+            elif first:
+                print(C.bold("Reminder Lists:"))
+                first = False
+            for r in rows:
+                secs = q_sections(db, r["Z_PK"])
+                list_name = format_list_title(r, db)
+                sec_info = C.dim(f" [{len(secs)} sections]") if secs else ""
+                pin_info = C.dim(" [pinned]") if _row_has_key(r, "ZISPINNEDBYCURRENTUSER") and r["ZISPINNEDBYCURRENTUSER"] else ""
+                id_dim = C.dim(f"(id: {r['Z_PK']})")
+                print(f"  {list_name} {id_dim}{sec_info}{pin_info}")
+            total += len(rows)
+        print(f"\n{total} list{'s' if total != 1 else ''}")
 
 REMINDERS_UI_CORE_BUNDLE = Path("/System/Library/PrivateFrameworks/RemindersUICore.framework")
 
@@ -5401,12 +6053,31 @@ def cmd_list_symbols(a):
         print(f"  {row['preview']:<2}  {row['name']:<{width}}  {C.dim(row['asset'])}")
 
 def cmd_show(a):
-    db = open_db()
-    list_ref = resolve_required_list_target_or_die(
-        db,
-        name=getattr(a, "list", None),
-        list_id=getattr(a, "list_id", None),
-    )
+    account_name = getattr(a, "account", None)
+    if _is_multi_account_mode(a):
+        scope = resolve_account_scope(a)
+        with iter_account_dbs(scope) as account_dbs:
+            result = resolve_list_ref_across(
+                account_dbs,
+                name=getattr(a, "list", None),
+                list_id=getattr(a, "list_id", None),
+                account_name=account_name,
+            )
+        if not result or result.get("error") == "ambiguous":
+            _print_list_resolution_error(getattr(a, "list", None) or str(getattr(a, "list_id", "")), result)
+            sys.exit(1)
+        # Re-open only the target account's connection for the actual query
+        store_path = Path(result["_store_path"])
+        db = sqlite3.connect(f"file:{store_path}?mode=ro", uri=True)
+        db.row_factory = sqlite3.Row
+        list_ref = result
+    else:
+        db = open_db()
+        list_ref = resolve_required_list_target_or_die(
+            db,
+            name=getattr(a, "list", None),
+            list_id=getattr(a, "list_id", None),
+        )
     pk = list_ref["id"]
     list_name = list_ref["title"]
     items = q_reminders(db, list_pk=pk, completed=a.completed, top_level=True)
@@ -5498,9 +6169,22 @@ def cmd_add(a):
     target_list_name = getattr(a, "list", None)
     list_resolution = None
     list_id = getattr(a, "list_id", None)
+    add_account_name = getattr(a, "account", None)
+    if isinstance(add_account_name, list):
+        add_account_name = add_account_name[0] if add_account_name else None
     if target_list_name or list_id is not None:
         try:
-            db = open_db()
+            if add_account_name:
+                matched = [ac for ac in discover_accounts()
+                           if ac.name.lower() == add_account_name.lower()]
+                if not matched:
+                    print(f"Error: account {add_account_name!r} not found. "
+                          f"Run 'remctl accounts' to see available accounts.", file=sys.stderr)
+                    sys.exit(1)
+                db = sqlite3.connect(f"file:{matched[0].store_path}?mode=ro", uri=True)
+                db.row_factory = sqlite3.Row
+            else:
+                db = open_db()
             list_resolution = resolve_list_or_die(db, name=target_list_name, list_id=list_id)
             target_list_pk = list_resolution["id"]
             target_list_name = list_resolution["title"]
@@ -5514,6 +6198,50 @@ def cmd_add(a):
             sys.exit(1)
         require_grocery_list_target(db, target_list_pk)
 
+    # Resolve calendarIdentifier for accurate multi-account write targeting.
+    # list_calendars returns [{title, calendarIdentifier, sourceTitle, sourceType}].
+    target_calendar_id = None
+    target_account = getattr(a, "account", None)
+    if isinstance(target_account, list):
+        target_account = target_account[0] if target_account else None
+    if (target_list_name or list_id is not None or target_account) and bridge_available():
+        try:
+            cals_result = bridge_call({"action": "list_calendars"})
+            cals = cals_result if isinstance(cals_result, list) else []
+            if target_list_name:
+                # Match by list name, optionally narrowed by account
+                matches = [c for c in cals if c.get("title") == target_list_name]
+                if target_account:
+                    acct_matches = [c for c in matches
+                                    if (c.get("sourceTitle") or "").lower() == target_account.lower()]
+                    if acct_matches:
+                        matches = acct_matches
+                if len(matches) == 1:
+                    target_calendar_id = matches[0].get("calendarIdentifier")
+                elif len(matches) > 1 and not target_account:
+                    sources = ", ".join(c.get("sourceTitle", "?") for c in matches)
+                    print(
+                        f"Error: List {target_list_name!r} exists in multiple accounts ({sources}). "
+                        "Use --account to specify which one.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+                elif len(matches) > 1:
+                    target_calendar_id = matches[0].get("calendarIdentifier")
+            elif target_account:
+                # No list specified — pick the first calendar in the named account
+                acct_cals = [c for c in cals if (c.get("sourceTitle") or "").lower() == target_account.lower()]
+                if not acct_cals:
+                    print(
+                        f"Error: No lists found in account {target_account!r}. "
+                        "Run 'remctl accounts' to see available accounts.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+                target_calendar_id = acct_cals[0].get("calendarIdentifier")
+        except Exception:
+            pass  # bridge list_calendars failed; fall back to title-only
+
     if a.tags and not wants_private:
         for t in a.tags.split(","):
             t = t.strip()
@@ -5523,7 +6251,12 @@ def cmd_add(a):
     # Try bridge first
     if bridge_available():
         data = {"action": "create", "title": title}
-        if target_list_name: data["list"] = target_list_name
+        if target_calendar_id:
+            data["calendarIdentifier"] = target_calendar_id
+        elif target_list_name:
+            data["list"] = target_list_name
+        if target_account:
+            data["account"] = target_account
         if a.notes: data["notes"] = a.notes
         if dt:
             data["due"] = dt.isoformat()
@@ -5552,8 +6285,29 @@ def cmd_add(a):
                 )
             try:
                 if db is None:
-                    db = open_db()
+                    if add_account_name:
+                        matched = [ac for ac in discover_accounts()
+                                   if ac.name.lower() == add_account_name.lower()]
+                        if matched:
+                            db = sqlite3.connect(f"file:{matched[0].store_path}?mode=ro", uri=True)
+                            db.row_factory = sqlite3.Row
+                        else:
+                            db = open_db()
+                    else:
+                        db = open_db()
                 created_row = q_reminder_by_identifier(db, result.get("id", ""))
+                # Exchange reminders have no ZCKIDENTIFIER — fall back to most-recent by title
+                if not created_row and title:
+                    try:
+                        created_row = db.execute(
+                            f"SELECT {rem_cols(db)} FROM ZREMCDREMINDER r "
+                            f"LEFT JOIN ZREMCDBASELIST l ON r.ZLIST = l.Z_PK "
+                            f"WHERE r.ZTITLE = ? AND r.ZMARKEDFORDELETION = 0 AND r.ZACCOUNT IS NOT NULL "
+                            f"ORDER BY r.Z_PK DESC LIMIT 1",
+                            (title,)
+                        ).fetchone()
+                    except Exception:
+                        pass
             except RemindersDBUnavailable:
                 created_row = None
             if a.json:
@@ -5566,7 +6320,10 @@ def cmd_add(a):
                         "method": list_resolution["method"],
                     }
                 if created_row:
-                    payload["numericId"] = created_row["Z_PK"]
+                    try:
+                        payload["numericId"] = created_row["Z_PK"]
+                    except (TypeError, KeyError, IndexError):
+                        pass
                 if private_results:
                     payload["private"] = private_results
                 print(json.dumps(payload))
@@ -5575,7 +6332,10 @@ def cmd_add(a):
                 if list_resolution and list_resolution.get("method") != "exact":
                     print(f"List: {safe_display(list_resolution['title'])} (resolved from {safe_display(list_resolution['requested'])})")
                 if created_row:
-                    print(f"ID: #{created_row['Z_PK']}")
+                    try:
+                        print(f"ID: #{created_row['Z_PK']}")
+                    except (TypeError, KeyError, IndexError):
+                        pass
                 if private_results:
                     print(f"Private metadata: applied {len(private_results)} update{'s' if len(private_results) != 1 else ''}")
             return
@@ -5646,17 +6406,141 @@ def _refuse_unsafe_title_fallback(reminder, operation, reason):
     )
     sys.exit(1)
 
-def cmd_done(a):
-    db = open_db()
-    r = q_reminder(db, a.id)
-    if not r:
-        print(f"Error: #{a.id} not found", file=sys.stderr)
+def _ek_identifier(r, account_name=None):
+    """Return the EventKit calendarItemIdentifier for a reminder row.
+
+    For iCloud reminders this is r["ZCKIDENTIFIER"].  For Exchange and other
+    non-CloudKit accounts that don't populate ZCKIDENTIFIER, the bridge is
+    queried via find_reminder using the list name and reminder title.
+    Returns None when no stable identifier can be resolved.
+    """
+    ck_id = r["ZCKIDENTIFIER"] if _item_has(r, "ZCKIDENTIFIER") else None
+    if ck_id:
+        return ck_id
+    if not bridge_available():
+        return None
+    list_name = r["list_name"] if _item_has(r, "list_name") else None
+    title = r["ZTITLE"] if _item_has(r, "ZTITLE") else None
+    if not list_name or not title:
+        return None
+    try:
+        cals = bridge_call({"action": "list_calendars"})
+        if not isinstance(cals, list):
+            return None
+        matches = [c for c in cals if c.get("title") == list_name]
+        if account_name:
+            acct_matches = [c for c in matches
+                            if (c.get("sourceTitle") or "").lower() == account_name.lower()]
+            if not acct_matches:
+                # An account was specified but no calendar of this name lives in it —
+                # refuse rather than target a same-named list in a different account.
+                return None
+            matches = acct_matches
+        if len(matches) != 1:
+            # Ambiguous (same list name in multiple accounts, no account hint) —
+            # do not guess which calendar to target.
+            return None
+        cal_id = matches[0].get("calendarIdentifier")
+        result = bridge_call({"action": "find_reminder", "calendarIdentifier": cal_id, "title": title})
+        if isinstance(result, dict):
+            return result.get("calendarItemIdentifier")
+    except Exception:
+        pass
+    return None
+
+
+def _open_db_for_account(account_name):
+    """Return an open read-only connection to the named account's store.
+
+    Falls back to open_db() when account_name is None or empty.
+    Exits with an error if the named account is not found.
+    """
+    if not account_name:
+        return open_db()
+    matched = [ac for ac in discover_accounts()
+               if ac.name.lower() == account_name.lower()]
+    if not matched:
+        print(f"Error: account {account_name!r} not found. "
+              f"Run 'remctl accounts' to see available accounts.", file=sys.stderr)
         sys.exit(1)
+    conn = sqlite3.connect(f"file:{matched[0].store_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _resolve_reminder_for_write(a):
+    """Open the right account's store and look up the reminder for a write command.
+
+    Resolution order:
+      1. --account NAME given → look only in that account.
+      2. Single-account default scope → open_db() (back-compat).
+      3. Multi-account scope (config/env 'all' or a named scope) → scan every
+         active account; a unique match wins, multiple matches raise an
+         ambiguity error asking for --account. The resolved account name is
+         stamped onto `a.account` so the downstream write path targets it.
+
+    Returns (db, row). Exits with an error if the reminder is not found.
+    The caller is responsible for closing db when done.
+    """
+    account_name = getattr(a, "account", None)
+    if account_name:
+        db = _open_db_for_account(account_name)
+        r = q_reminder(db, a.id)
+        if not r:
+            print(f"Error: #{a.id} not found in account {account_name!r}", file=sys.stderr)
+            sys.exit(1)
+        return db, r
+
+    # Pure default scope: preserve exact single-account behavior (open_db()).
+    if not _is_multi_account_mode(a):
+        db = open_db()
+        r = q_reminder(db, a.id)
+        if not r:
+            print(f"Error: #{a.id} not found", file=sys.stderr)
+            sys.exit(1)
+        return db, r
+
+    # Multi-account scope: scan all active accounts for the id.
+    scope = resolve_account_scope(a)
+    hits = []  # (Account, conn, row)
+    conns = []
+    for acct in scope:
+        conn = sqlite3.connect(f"file:{acct.store_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        conns.append(conn)
+        row = q_reminder(conn, a.id)
+        if row:
+            hits.append((acct, conn, row))
+    if not hits:
+        for c in conns:
+            c.close()
+        print(f"Error: #{a.id} not found in any active account", file=sys.stderr)
+        sys.exit(1)
+    if len(hits) > 1:
+        names = ", ".join(h[0].name for h in hits)
+        for c in conns:
+            c.close()
+        print(f"Error: reminder id {a.id} exists in multiple accounts ({names}). "
+              "Use --account to specify which one.", file=sys.stderr)
+        sys.exit(1)
+    acct, db, row = hits[0]
+    # Close the non-winning connections; keep the winner open for the caller.
+    for c in conns:
+        if c is not db:
+            c.close()
+    # Record the resolved account so the write path (bridge/_ek_identifier) targets it.
+    a.account = acct.name
+    return db, row
+
+
+def cmd_done(a):
+    db, r = _resolve_reminder_for_write(a)
+    ek_id = _ek_identifier(r, getattr(a, "account", None))
 
     # Bridge-first for speed (post-2026-04-17 bridge fix: dueDateComponents
     # now reach CloudKit correctly). AppleScript stays as a fallback.
-    if bridge_available() and r["ZCKIDENTIFIER"]:
-        data = {"action": "complete", "id": r["ZCKIDENTIFIER"]}
+    if bridge_available() and ek_id:
+        data = {"action": "complete", "id": ek_id}
         result = bridge_call(data)
         if result and result.get("status") == "completed":
             if a.json:
@@ -5682,15 +6566,12 @@ def cmd_done(a):
     )
 
 def cmd_undone(a):
-    db = open_db()
-    r = q_reminder(db, a.id)
-    if not r:
-        print(f"Error: #{a.id} not found", file=sys.stderr)
-        sys.exit(1)
+    db, r = _resolve_reminder_for_write(a)
+    ek_id = _ek_identifier(r, getattr(a, "account", None))
 
     # Bridge-first for speed; AppleScript fallback.
-    if bridge_available() and r["ZCKIDENTIFIER"]:
-        data = {"action": "uncomplete", "id": r["ZCKIDENTIFIER"]}
+    if bridge_available() and ek_id:
+        data = {"action": "uncomplete", "id": ek_id}
         result = bridge_call(data)
         if result and result.get("status") == "uncompleted":
             if a.json:
@@ -5715,11 +6596,8 @@ def cmd_undone(a):
     )
 
 def cmd_delete(a):
-    db = open_db()
-    r = q_reminder(db, a.id)
-    if not r:
-        print(f"Error: #{a.id} not found", file=sys.stderr)
-        sys.exit(1)
+    db, r = _resolve_reminder_for_write(a)
+    ek_id = _ek_identifier(r, getattr(a, "account", None))
     if not a.force:
         ans = input(f"Delete '{safe_display(r['ZTITLE'])}' from {safe_display(r['list_name'])}? [y/N] ")
         if not ans.lower().startswith("y"):
@@ -5727,8 +6605,8 @@ def cmd_delete(a):
             return
 
     # Bridge-first for speed; AppleScript fallback.
-    if bridge_available() and r["ZCKIDENTIFIER"]:
-        data = {"action": "delete", "id": r["ZCKIDENTIFIER"]}
+    if bridge_available() and ek_id:
+        data = {"action": "delete", "id": ek_id}
         result = bridge_call(data)
         if result and result.get("status") == "deleted":
             if a.json:
@@ -5757,11 +6635,8 @@ def cmd_edit(a):
     if getattr(a, "tags", None) and not private_metadata_enabled(a):
         print("Error: editing synced tags requires --private.", file=sys.stderr)
         sys.exit(1)
-    db = open_db()
-    r = q_reminder(db, a.id)
-    if not r:
-        print(f"Error: #{a.id} not found", file=sys.stderr)
-        sys.exit(1)
+    db, r = _resolve_reminder_for_write(a)
+    ek_id = _ek_identifier(r, getattr(a, "account", None))
     target_list_ref = None
     target_list_name = getattr(a, "list", None)
     target_list_id = getattr(a, "list_id", None)
@@ -5846,14 +6721,14 @@ def cmd_edit(a):
     # Double-tap defense: if the displayed date already equals the new target,
     # fire an intermediate update first so the CKRecord is forced to carry a
     # real dueDateComponents change.
-    if bridge_available() and r["ZCKIDENTIFIER"]:
+    if bridge_available() and ek_id:
         if dt_nudge is not None:
             bridge_call({
                 "action": "update",
-                "id": r["ZCKIDENTIFIER"],
+                "id": ek_id,
                 "due": dt_nudge.isoformat(),
             })
-        data = {"action": "update", "id": r["ZCKIDENTIFIER"]}
+        data = {"action": "update", "id": ek_id}
         has_changes = False
         if a.title: data["title"] = a.title; has_changes = True
         if target_list_ref:
@@ -5887,7 +6762,7 @@ def cmd_edit(a):
             result = bridge_call(data)
             if result and result.get("status") == "updated":
                 private_results = apply_private_changes(
-                    r["ZCKIDENTIFIER"],
+                    ek_id,
                     a,
                     db=db,
                     list_pk=target_list_pk,
@@ -5915,7 +6790,7 @@ def cmd_edit(a):
                 return
         elif wants_private:
             private_results = apply_private_changes(
-                r["ZCKIDENTIFIER"],
+                ek_id,
                 a,
                 db=db,
                 list_pk=target_list_pk,
@@ -5942,7 +6817,7 @@ def cmd_edit(a):
         or (hasattr(a, 'url') and a.url and not wants_private)
     )
 
-    if r["ZCKIDENTIFIER"] and has_applescript_fields and not has_bridge_only:
+    if ek_id and has_applescript_fields and not has_bridge_only:
         parts = []
         if a.title:
             parts.append(f'set name of r to "{esc(a.title)}"')
@@ -5970,7 +6845,7 @@ def cmd_edit(a):
     if not has_applescript_fields and not has_bridge_only:
         print("Nothing to update.")
         return
-    if not r["ZCKIDENTIFIER"]:
+    if not ek_id:
         _refuse_unsafe_title_fallback(r, "edit it", "The reminder has no stable identifier")
     _refuse_unsafe_title_fallback(
         r,
@@ -5980,93 +6855,265 @@ def cmd_edit(a):
 
 
 def cmd_search(a):
-    db = open_db()
-    items = q_search(db, a.query, completed=a.completed)
-    pks = [i["Z_PK"] for i in items]
-    sc, ht = preload_extras(db, pks)
+    if not _is_multi_account_mode(a):
+        db = open_db()
+        items = q_search(db, a.query, completed=a.completed)
+        pks = [i["Z_PK"] for i in items]
+        sc, ht = preload_extras(db, pks)
+        if a.json:
+            print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+            return
+        if getattr(a, 'format', None) == 'table':
+            print(fmt_table(reminders_to_table_data(items, db)))
+            return
+        if not items:
+            print(f"No reminders matching '{safe_display(a.query)}'")
+            return
+        print(f"Search: {C.bold(safe_display(a.query))}")
+        for i in items:
+            print(fmt(i, db, verbose=a.verbose, _sc=sc, _ht=ht))
+        print(f"\n{len(items)} result{'s' if len(items) != 1 else ''}")
+        return
+    scope = resolve_account_scope(a)
+    multi = len(scope) > 1
     if a.json:
-        print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+        dicts = gather_reminder_dicts(scope, lambda db: q_search(db, a.query, completed=a.completed))
+        print(json.dumps(dicts, indent=2))
         return
     if getattr(a, 'format', None) == 'table':
-        print(fmt_table(reminders_to_table_data(items, db)))
+        print(fmt_table(gather_table_rows(scope, lambda db: q_search(db, a.query, completed=a.completed))))
         return
-    if not items:
+    # Single-account search has no indent (matches original); only indent under
+    # account group headers when actually showing more than one account.
+    item_indent = "  " if multi else ""
+    groups = []
+    with iter_account_dbs(scope) as account_dbs:
+        for acct, db in account_dbs:
+            items = q_search(db, a.query, completed=a.completed)
+            pks = [i["Z_PK"] for i in items]
+            sc, ht = preload_extras(db, pks)
+            lines = [fmt(i, db, verbose=a.verbose, indent=item_indent, _sc=sc, _ht=ht) for i in items]
+            if lines:
+                groups.append((acct.name if multi else None, lines))
+    total = sum(len(g[1]) for g in groups)
+    if not total:
         print(f"No reminders matching '{safe_display(a.query)}'")
         return
     print(f"Search: {C.bold(safe_display(a.query))}")
-    for i in items:
-        print(fmt(i, db, verbose=a.verbose, _sc=sc, _ht=ht))
-    print(f"\n{len(items)} result{'s' if len(items) != 1 else ''}")
+    for acct_name, lines in groups:
+        if acct_name:
+            print(f"\n  {C.bold(acct_name)}")
+        for line in lines:
+            print(line)
+    print(f"\n{total} result{'s' if total != 1 else ''}")
 
 def cmd_today(a):
-    db = open_db()
-    items = q_due_today(db, include_overdue=not a.no_overdue)
-    pks = [i["Z_PK"] for i in items]
-    sc, ht = preload_extras(db, pks)
+    if not _is_multi_account_mode(a):
+        db = open_db()
+        items = q_due_today(db, include_overdue=not a.no_overdue)
+        pks = [i["Z_PK"] for i in items]
+        sc, ht = preload_extras(db, pks)
+        if a.json:
+            print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+            return
+        if getattr(a, 'format', None) == 'table':
+            print(fmt_table(reminders_to_table_data(items, db)))
+            return
+        if not items:
+            print(f"Nothing due today ({datetime.now().strftime('%Y-%m-%d')})")
+            return
+        sod = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        overdue = [i for i in items if ts(row_effective_due(i)) < sod]
+        overdue_pks = {i["Z_PK"] for i in overdue}
+        due = [i for i in items if i["Z_PK"] not in overdue_pks]
+        if overdue:
+            print(C.red(f"Overdue ({len(overdue)}):"))
+            for i in overdue:
+                print(fmt(i, db, indent="  ", _sc=sc, _ht=ht))
+            print()
+        if due:
+            print(C.bold(f"Due Today ({len(due)}):"))
+            for i in due:
+                print(fmt(i, db, indent="  ", _sc=sc, _ht=ht))
+        print(f"\n{len(items)} total")
+        return
+    scope = resolve_account_scope(a)
+    multi = len(scope) > 1
     if a.json:
-        print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+        dicts = gather_reminder_dicts(scope, lambda db: q_due_today(db, include_overdue=not a.no_overdue))
+        print(json.dumps(dicts, indent=2))
         return
     if getattr(a, 'format', None) == 'table':
-        print(fmt_table(reminders_to_table_data(items, db)))
-        return
-    if not items:
-        print(f"Nothing due today ({datetime.now().strftime('%Y-%m-%d')})")
+        print(fmt_table(gather_table_rows(scope, lambda db: q_due_today(db, include_overdue=not a.no_overdue))))
         return
     sod = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-    overdue = [i for i in items if ts(row_effective_due(i)) < sod]
-    overdue_pks = {i["Z_PK"] for i in overdue}
-    due = [i for i in items if i["Z_PK"] not in overdue_pks]
-    if overdue:
-        print(C.red(f"Overdue ({len(overdue)}):"))
-        for i in overdue:
-            print(fmt(i, db, indent="  ", _sc=sc, _ht=ht))
+    # Each entry: (acct_name_or_None, overdue_lines, due_lines)
+    groups = []
+    with iter_account_dbs(scope) as account_dbs:
+        for acct, db in account_dbs:
+            items = q_due_today(db, include_overdue=not a.no_overdue)
+            pks = [i["Z_PK"] for i in items]
+            sc, ht = preload_extras(db, pks)
+            ov, due = [], []
+            for i in items:
+                line = fmt(i, db, indent="  ", _sc=sc, _ht=ht)
+                (ov if ts(row_effective_due(i)) < sod else due).append(line)
+            if ov or due:
+                groups.append((acct.name if multi else None, ov, due))
+    total = sum(len(g[1]) + len(g[2]) for g in groups)
+    if not total:
+        print(f"Nothing due today ({datetime.now().strftime('%Y-%m-%d')})")
+        return
+    total_overdue = sum(len(g[1]) for g in groups)
+    total_due = sum(len(g[2]) for g in groups)
+    if total_overdue:
+        print(C.red(f"Overdue ({total_overdue}):"))
+        for acct_name, ov, _ in groups:
+            if acct_name and ov:
+                print(f"\n  {C.bold(acct_name)}")
+            for line in ov:
+                print(line)
         print()
-    if due:
-        print(C.bold(f"Due Today ({len(due)}):"))
-        for i in due:
-            print(fmt(i, db, indent="  ", _sc=sc, _ht=ht))
-    print(f"\n{len(items)} total")
+    if total_due:
+        print(C.bold(f"Due Today ({total_due}):"))
+        for acct_name, _, due in groups:
+            if acct_name and due:
+                print(f"\n  {C.bold(acct_name)}")
+            for line in due:
+                print(line)
+    print(f"\n{total} total")
 
 def cmd_flagged(a):
-    db = open_db()
-    items = q_flagged(db)
-    pks = [i["Z_PK"] for i in items]
-    sc, ht = preload_extras(db, pks)
+    if not _is_multi_account_mode(a):
+        db = open_db()
+        items = q_flagged(db)
+        pks = [i["Z_PK"] for i in items]
+        sc, ht = preload_extras(db, pks)
+        if a.json:
+            print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+            return
+        if getattr(a, 'format', None) == 'table':
+            print(fmt_table(reminders_to_table_data(items, db)))
+            return
+        if not items:
+            print("No flagged reminders")
+            return
+        print(C.bold("Flagged:"))
+        for i in items:
+            print(fmt(i, db, verbose=a.verbose, indent="  ", _sc=sc, _ht=ht))
+        print(f"\n{len(items)} flagged")
+        return
+    scope = resolve_account_scope(a)
+    multi = len(scope) > 1
     if a.json:
-        print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+        dicts = gather_reminder_dicts(scope, q_flagged)
+        print(json.dumps(dicts, indent=2))
         return
     if getattr(a, 'format', None) == 'table':
-        print(fmt_table(reminders_to_table_data(items, db)))
+        print(fmt_table(gather_table_rows(scope, q_flagged)))
         return
-    if not items:
+    groups = []
+    with iter_account_dbs(scope) as account_dbs:
+        for acct, db in account_dbs:
+            items = q_flagged(db)
+            pks = [i["Z_PK"] for i in items]
+            sc, ht = preload_extras(db, pks)
+            lines = [fmt(i, db, verbose=a.verbose, indent="  ", _sc=sc, _ht=ht) for i in items]
+            if lines:
+                groups.append((acct.name if multi else None, lines))
+    total = sum(len(g[1]) for g in groups)
+    if not total:
         print("No flagged reminders")
         return
     print(C.bold("Flagged:"))
-    for i in items:
-        print(fmt(i, db, verbose=a.verbose, indent="  ", _sc=sc, _ht=ht))
-    print(f"\n{len(items)} flagged")
+    for acct_name, lines in groups:
+        if acct_name:
+            print(f"\n  {C.bold(acct_name)}")
+        for line in lines:
+            print(line)
+    print(f"\n{total} flagged")
 
 def cmd_urgent(a):
-    db = open_db()
-    items = q_urgent(db)
-    pks = [i["Z_PK"] for i in items]
-    sc, ht = preload_extras(db, pks)
+    if not _is_multi_account_mode(a):
+        db = open_db()
+        items = q_urgent(db)
+        pks = [i["Z_PK"] for i in items]
+        sc, ht = preload_extras(db, pks)
+        if a.json:
+            print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+            return
+        if getattr(a, 'format', None) == 'table':
+            print(fmt_table(reminders_to_table_data(items, db)))
+            return
+        if not items:
+            print("No urgent reminders")
+            return
+        print(C.bold("Urgent:"))
+        for i in items:
+            print(fmt(i, db, verbose=a.verbose, indent="  ", _sc=sc, _ht=ht))
+        print(f"\n{len(items)} urgent")
+        return
+    scope = resolve_account_scope(a)
+    multi = len(scope) > 1
     if a.json:
-        print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+        dicts = gather_reminder_dicts(scope, q_urgent)
+        print(json.dumps(dicts, indent=2))
         return
     if getattr(a, 'format', None) == 'table':
-        print(fmt_table(reminders_to_table_data(items, db)))
+        print(fmt_table(gather_table_rows(scope, q_urgent)))
         return
-    if not items:
+    groups = []
+    with iter_account_dbs(scope) as account_dbs:
+        for acct, db in account_dbs:
+            items = q_urgent(db)
+            pks = [i["Z_PK"] for i in items]
+            sc, ht = preload_extras(db, pks)
+            lines = [fmt(i, db, verbose=a.verbose, indent="  ", _sc=sc, _ht=ht) for i in items]
+            if lines:
+                groups.append((acct.name if multi else None, lines))
+    total = sum(len(g[1]) for g in groups)
+    if not total:
         print("No urgent reminders")
         return
     print(C.bold("Urgent:"))
-    for i in items:
-        print(fmt(i, db, verbose=a.verbose, indent="  ", _sc=sc, _ht=ht))
-    print(f"\n{len(items)} urgent")
+    for acct_name, lines in groups:
+        if acct_name:
+            print(f"\n  {C.bold(acct_name)}")
+        for line in lines:
+            print(line)
+    print(f"\n{total} urgent")
 
 def cmd_tags(a):
-    db = open_db()
+    if _is_multi_account_mode(a):
+        scope = resolve_account_scope(a)
+        seen = set()
+        all_tags = []
+        with iter_account_dbs(scope) as account_dbs:
+            for acct, db in account_dbs:
+                try:
+                    rows = db.execute(
+                        "SELECT ZNAME FROM ZREMCDHASHTAGLABEL WHERE ZNAME IS NOT NULL ORDER BY ZNAME"
+                    ).fetchall()
+                    for r in rows:
+                        name = r["ZNAME"]
+                        if name not in seen:
+                            seen.add(name)
+                            all_tags.append(name)
+                except Exception:
+                    pass
+        all_tags.sort()
+        if a.json:
+            print(json.dumps([{"name": t} for t in all_tags], indent=2))
+            return
+        if not all_tags:
+            print("No tags found")
+            return
+        print(C.bold("Tags:"))
+        for t in all_tags:
+            print(f"  {C.magenta('#' + safe_display(t))}")
+        print(f"\n{len(all_tags)} tag{'s' if len(all_tags) != 1 else ''}")
+        return
+    db = _open_db_for_account(getattr(a, "account", None))
     rows = db.execute(
         "SELECT ZNAME FROM ZREMCDHASHTAGLABEL WHERE ZNAME IS NOT NULL ORDER BY ZNAME"
     ).fetchall()
@@ -6082,11 +7129,7 @@ def cmd_tags(a):
     print(f"\n{len(rows)} tag{'s' if len(rows) != 1 else ''}")
 
 def cmd_subtasks(a):
-    db = open_db()
-    parent = q_reminder(db, a.id)
-    if not parent:
-        print(f"Error: #{a.id} not found", file=sys.stderr)
-        sys.exit(1)
+    db, parent = _resolve_reminder_for_write(a)
     subs = q_reminders(db, parent_pk=a.id, completed=True)
     sub_pks = [s["Z_PK"] for s in subs]
     sc, ht = preload_extras(db, sub_pks)
@@ -6104,11 +7147,7 @@ def cmd_subtasks(a):
         print(f"\n{len(subs)} subtask{'s' if len(subs) != 1 else ''}")
 
 def cmd_info(a):
-    db = open_db()
-    r = q_reminder(db, a.id)
-    if not r:
-        print(f"Error: #{a.id} not found", file=sys.stderr)
-        sys.exit(1)
+    db, r = _resolve_reminder_for_write(a)
     subs = q_reminders(db, parent_pk=a.id, completed=True)
     atts = q_attachments(db, a.id)
     alarms = q_alarms(db, a.id)
@@ -6135,9 +7174,10 @@ def cmd_info(a):
     print(f"  Status:    {status_str}")
     pri_val = r["ZPRIORITY"] or 0
     pri_display = PRI_NAME.get(pri_val, "none")
-    if pri_val == 1: pri_display = C.red(pri_display)
-    elif pri_val == 5: pri_display = C.yellow(pri_display)
-    elif pri_val == 9: pri_display = C.green(pri_display)
+    pri_bucket = priority_bucket(pri_val)
+    if pri_bucket == "high": pri_display = C.red(pri_display)
+    elif pri_bucket == "medium": pri_display = C.yellow(pri_display)
+    elif pri_bucket == "low": pri_display = C.green(pri_display)
     print(f"  Priority:  {pri_display}")
     flagged_str = C.yellow("Yes") if r["ZFLAGGED"] else "No"
     print(f"  Flagged:   {flagged_str}")
@@ -6199,7 +7239,38 @@ def cmd_info(a):
         print(f"  Deep link: {C.dim(link)}")
 
 def cmd_sections(a):
-    db = open_db()
+    scope = resolve_account_scope(a) if _is_multi_account_mode(a) else None
+    if scope:
+        multi = len(scope) > 1
+        all_rows = []
+        with iter_account_dbs(scope) as account_dbs:
+            for acct, db in account_dbs:
+                rows = q_sections(db)
+                for r in rows:
+                    all_rows.append((acct.name, r, db))
+        if a.json:
+            out = {}
+            for acct_name, r, _ in all_rows:
+                key = f"{acct_name}/{r['list_name'] or '?'}" if multi else (r["list_name"] or "?")
+                out.setdefault(key, []).append(r["ZDISPLAYNAME"])
+            print(json.dumps(out, indent=2))
+            return
+        if not all_rows:
+            print("No sections found")
+            return
+        cur = None
+        for acct_name, r, db in all_rows:
+            ln = r["list_name"] or "?"
+            label = f"{acct_name}/{ln}" if multi else ln
+            if label != cur:
+                if cur: print()
+                acct_suffix = f" {C.dim(f'({acct_name})')}" if multi else ""
+                print(f"{C.bold(color_list_name(ln, db))}{acct_suffix}:")
+                cur = label
+            print(f"  - {safe_display(r['ZDISPLAYNAME'])}")
+        print(f"\n{len(all_rows)} section{'s' if len(all_rows) != 1 else ''}")
+        return
+    db = _open_db_for_account(getattr(a, "account", None))
     rows = q_sections(db)
     if a.json:
         out = {}
@@ -6222,14 +7293,43 @@ def cmd_sections(a):
 
 
 def cmd_sharees(a):
-    db = open_db()
-    list_ref = resolve_required_list_target_or_die(
-        db,
-        name=getattr(a, "list", None),
-        list_id=getattr(a, "list_id", None),
-    )
-    current_user_ckid = q_list_shared_owner_ckid(db, list_ref["id"])
-    rows = q_sharees(db, list_ref["id"])
+    account_name = getattr(a, "account", None)
+    if _is_multi_account_mode(a):
+        scope = resolve_account_scope(a)
+        with iter_account_dbs(scope) as account_dbs:
+            list_ref = resolve_list_ref_across(
+                account_dbs,
+                name=getattr(a, "list", None),
+                list_id=getattr(a, "list_id", None),
+                account_name=account_name,
+            )
+            if not list_ref or list_ref.get("error") == "ambiguous":
+                _print_list_resolution_error(getattr(a, "list", None) or str(getattr(a, "list_id", "")), list_ref)
+                sys.exit(1)
+            # Read sharees using the connection already open for the matching
+            # store, so we never reconnect after iter_account_dbs() closes them.
+            db = next(
+                (d for acct, d in account_dbs if str(acct.store_path) == list_ref["_store_path"]),
+                None,
+            )
+            current_user_ckid = q_list_shared_owner_ckid(db, list_ref["id"])
+            rows = q_sharees(db, list_ref["id"])
+        # Strip internal/multi-only fields so single-account output stays
+        # byte-identical to the original; keep account labels only when the
+        # active scope actually spans more than one account.
+        list_ref.pop("_store_path", None)
+        if len(scope) <= 1:
+            list_ref.pop("account", None)
+            list_ref.pop("accountType", None)
+    else:
+        db = open_db()
+        list_ref = resolve_required_list_target_or_die(
+            db,
+            name=getattr(a, "list", None),
+            list_id=getattr(a, "list_id", None),
+        )
+        current_user_ckid = q_list_shared_owner_ckid(db, list_ref["id"])
+        rows = q_sharees(db, list_ref["id"])
     payload = {
         "list": list_ref,
         "currentUserSharee": current_user_ckid,
@@ -6249,9 +7349,8 @@ def cmd_sharees(a):
     print(f"\n{len(rows)} sharee{'s' if len(rows) != 1 else ''}")
 
 
-def cmd_stats(a):
-    db = open_db()
-    due_column = due_expr()
+def _gather_stats(db):
+    """Return a stats dict for a single database connection."""
     total = db.execute("SELECT COUNT(*) FROM ZREMCDREMINDER WHERE ZMARKEDFORDELETION = 0 AND ZACCOUNT IS NOT NULL").fetchone()[0]
     active = db.execute("SELECT COUNT(*) FROM ZREMCDREMINDER WHERE ZMARKEDFORDELETION = 0 AND ZCOMPLETED = 0 AND ZACCOUNT IS NOT NULL").fetchone()[0]
     flagged = db.execute("SELECT COUNT(*) FROM ZREMCDREMINDER WHERE ZMARKEDFORDELETION = 0 AND ZCOMPLETED = 0 AND ZFLAGGED = 1 AND ZACCOUNT IS NOT NULL").fetchone()[0]
@@ -6259,68 +7358,145 @@ def cmd_stats(a):
         f"SELECT COUNT(*) FROM ZREMCDREMINDER r WHERE r.ZMARKEDFORDELETION = 0 "
         f"AND r.ZCOMPLETED = 0 AND r.ZACCOUNT IS NOT NULL AND {urgent_where_clause(db)}"
     ).fetchone()[0]
+    # Overdue uses the same canonical definition as q_overdue() and the `today`
+    # view: all-day-aware due date earlier than the start of today. This keeps
+    # the "Overdue" count identical to what `remctl overdue` actually lists.
+    due_column = due_filter_expr(db)
+    sod_ts = to_ts(start_of_day())
     overdue = db.execute(
-        f"SELECT COUNT(*) FROM ZREMCDREMINDER r WHERE r.ZMARKEDFORDELETION = 0 AND r.ZCOMPLETED = 0 AND r.ZACCOUNT IS NOT NULL "
-        f"AND {due_column} IS NOT NULL AND {due_column} < {to_ts(datetime.now())}"
+        f"SELECT COUNT(*) FROM ZREMCDREMINDER r LEFT JOIN ZREMCDBASELIST l "
+        f"ON r.ZLIST = l.Z_PK WHERE r.ZMARKEDFORDELETION = 0 AND r.ZCOMPLETED = 0 AND r.ZACCOUNT IS NOT NULL "
+        f"AND l.Z_PK IS NOT NULL AND {due_column} IS NOT NULL AND {due_column} < {sod_ts}"
     ).fetchone()[0]
-    lists_count = len(q_lists(db))
-    sections_count = len(q_sections(db))
-    if a.json:
-        print(json.dumps({
-            "total": total, "active": active, "completed": total - active,
-            "overdue": overdue, "flagged": flagged, "urgent": urgent,
-            "lists": lists_count, "sections": sections_count
-        }, indent=2))
+    return {
+        "total": total, "active": active, "completed": total - active,
+        "overdue": overdue, "flagged": flagged, "urgent": urgent,
+        "lists": len(q_lists(db)), "sections": len(q_sections(db)),
+    }
+
+
+def _print_stats(stats, heading="Reminders Stats"):
+    print(C.bold(heading))
+    print(f"  Total:      {stats['total']}")
+    print(f"  Active:     {C.green(str(stats['active']))}")
+    print(f"  Completed:  {C.dim(str(stats['completed']))}")
+    print(f"  Overdue:    {C.red(str(stats['overdue'])) if stats['overdue'] else '0'}")
+    print(f"  Flagged:    {C.yellow(str(stats['flagged'])) if stats['flagged'] else '0'}")
+    print(f"  Urgent:     {C.red(str(stats['urgent'])) if stats['urgent'] else '0'}")
+    print(f"  Lists:      {stats['lists']}")
+    print(f"  Sections:   {stats['sections']}")
+
+
+def cmd_stats(a):
+    scope = resolve_account_scope(a) if _is_multi_account_mode(a) else None
+    if scope and len(scope) > 1:
+        # Multi-account: per-account breakdown + combined total
+        per_account = {}
+        totals = {"total": 0, "active": 0, "completed": 0, "overdue": 0,
+                  "flagged": 0, "urgent": 0, "lists": 0, "sections": 0}
+        with iter_account_dbs(scope) as account_dbs:
+            for acct, db in account_dbs:
+                s = _gather_stats(db)
+                per_account[acct.name] = s
+                for k in totals:
+                    totals[k] += s[k]
+        if a.json:
+            print(json.dumps({"total": totals, "accounts": per_account}, indent=2))
+            return
+        for acct_name, s in per_account.items():
+            _print_stats(s, heading=f"Stats: {acct_name}")
+            print()
+        _print_stats(totals, heading="Stats: All Accounts")
         return
-    print(C.bold("Reminders Stats"))
-    print(f"  Total:      {total}")
-    print(f"  Active:     {C.green(str(active))}")
-    print(f"  Completed:  {C.dim(str(total - active))}")
-    print(f"  Overdue:    {C.red(str(overdue)) if overdue else '0'}")
-    print(f"  Flagged:    {C.yellow(str(flagged)) if flagged else '0'}")
-    print(f"  Urgent:     {C.red(str(urgent)) if urgent else '0'}")
-    print(f"  Lists:      {lists_count}")
-    print(f"  Sections:   {sections_count}")
+    # Single account (default, or a single named/scoped account): original flat format
+    if scope:
+        with iter_account_dbs(scope) as account_dbs:
+            stats = _gather_stats(account_dbs[0][1])
+    else:
+        stats = _gather_stats(open_db())
+    if a.json:
+        print(json.dumps(stats, indent=2))
+        return
+    _print_stats(stats)
+
+def _emit_links(results, a):
+    """Render link results. Each result carries a pre-rendered 'id_text' so the
+    source db connection can be closed before printing (needed for multi-account)."""
+    if a.json:
+        print(json.dumps([{"id": r["id"], "title": r["title"], "link": r["link"]} for r in results], indent=2))
+    else:
+        for r in results:
+            print(f"{r['id_text']} {safe_display(r['title'])}")
+            print(f"  {C.dim(r['link'])}")
+
 
 def cmd_link(a):
-    db = open_db()
+    account_name = getattr(a, "account", None)
     ids = a.ids
     list_name = getattr(a, "list", None)
     list_id = getattr(a, "list_id", None)
     if ids and (list_name or list_id is not None):
         print("Error: pass reminder IDs or a list target, not both.", file=sys.stderr)
         sys.exit(1)
+
+    results = []
+    def add_result(rid, r, db):
+        if r["ZCKIDENTIFIER"]:
+            results.append({
+                "id": rid, "title": r["ZTITLE"],
+                "link": f"x-apple-reminderkit://REMCDReminder/{r['ZCKIDENTIFIER']}",
+                "id_text": reminder_id_text(rid, r["list_name"], db),
+            })
+
+    if _is_multi_account_mode(a):
+        scope = resolve_account_scope(a)
+        with iter_account_dbs(scope) as account_dbs:
+            if list_name or list_id is not None:
+                ref = resolve_list_ref_across(account_dbs, name=list_name, list_id=list_id, account_name=account_name)
+                if not ref or ref.get("error") == "ambiguous":
+                    _print_list_resolution_error(list_name or str(list_id), ref)
+                    sys.exit(1)
+                tdb = next((db for acct, db in account_dbs if str(acct.store_path) == ref["_store_path"]), None)
+                for i in q_reminders(tdb, list_pk=ref["id"], completed=a.completed, top_level=True):
+                    add_result(i["Z_PK"], i, tdb)
+            else:
+                if not ids:
+                    print("No reminders specified.", file=sys.stderr)
+                    sys.exit(1)
+                for rid in ids:
+                    hit = None
+                    for acct, db in account_dbs:
+                        r = q_reminder(db, rid)
+                        if r:
+                            hit = (db, r)
+                            break
+                    if hit is None:
+                        print(f"Warning: #{rid} not found", file=sys.stderr)
+                        continue
+                    add_result(rid, hit[1], hit[0])
+            _emit_links(results, a)
+        return
+
+    # Default single-account
+    db = open_db()
     if list_name or list_id is not None:
         list_ref = resolve_required_list_target_or_die(db, name=list_name, list_id=list_id)
-        pk = list_ref["id"]
-        items = q_reminders(db, list_pk=pk, completed=a.completed, top_level=True)
+        items = q_reminders(db, list_pk=list_ref["id"], completed=a.completed, top_level=True)
         ids = [i["Z_PK"] for i in items]
     if not ids:
         print("No reminders specified.", file=sys.stderr)
         sys.exit(1)
-    results = []
     for rid in ids:
         r = q_reminder(db, rid)
         if not r:
             print(f"Warning: #{rid} not found", file=sys.stderr)
             continue
-        if r["ZCKIDENTIFIER"]:
-            link = f"x-apple-reminderkit://REMCDReminder/{r['ZCKIDENTIFIER']}"
-            results.append({"id": rid, "title": r["ZTITLE"], "link": link, "_list_name": r["list_name"]})
-    if a.json:
-        print(json.dumps([{k: v for k, v in item.items() if not k.startswith("_")} for item in results], indent=2))
-    else:
-        for item in results:
-            print(f"{reminder_id_text(item['id'], item.get('_list_name'), db)} {safe_display(item['title'])}")
-            print(f"  {C.dim(item['link'])}")
+        add_result(rid, r, db)
+    _emit_links(results, a)
 
 def cmd_open(a):
     if hasattr(a, 'id') and a.id:
-        db = open_db()
-        r = q_reminder(db, a.id)
-        if not r:
-            print(f"Error: #{a.id} not found", file=sys.stderr)
-            sys.exit(1)
+        db, r = _resolve_reminder_for_write(a)
         if r["ZCKIDENTIFIER"]:
             link = f"x-apple-reminderkit://REMCDReminder/{r['ZCKIDENTIFIER']}"
             subprocess.run(["open", link])
@@ -6334,75 +7510,60 @@ def cmd_open(a):
 
 # ── New Commands ─────────────────────────────────────────────────────────────
 
-def cmd_flag(a):
-    db = open_db()
-    r = q_reminder(db, a.id)
-    if not r:
-        print(f"Error: #{a.id} not found", file=sys.stderr)
-        sys.exit(1)
+def _refuse_flag_unsupported(a, r, verb):
+    """Exit with an honest error when flag state can't be set for this account.
 
-    # AppleScript-first for flag/unflag: EventKit has no public "flagged"
-    # property, so the bridge approximates it with priority=1, which loses
-    # the real priority value. AppleScript `set flagged of r` touches the
-    # actual ZFLAGGED column — the only correct path.
+    The real flag lives in ZFLAGGED, which only AppleScript can write — and that
+    requires the iCloud x-apple-reminder:// identifier. Exchange and other CalDAV
+    accounts have no such identifier and no flag attribute, so flagging is not
+    supported there; the EventKit priority proxy would be misleading.
+    """
+    account_name = getattr(a, "account", None)
+    acct = f" in account {account_name!r}" if account_name else ""
+    title = r["ZTITLE"] if _item_has(r, "ZTITLE") else "?"
+    hint_account = f" --account {account_name}" if account_name else ""
+    print(
+        f"Error: cannot {verb} #{a.id} ({safe_display(title)}){acct}. "
+        "Reminder flags are stored only for iCloud and on-device lists; "
+        "Exchange/CalDAV accounts have no flag attribute. "
+        f"Use priority instead, e.g. `remctl edit {a.id}{hint_account} -p high`.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def cmd_flag(a):
+    db, r = _resolve_reminder_for_write(a)
+
+    # Only AppleScript can set the real ZFLAGGED flag, and it needs the iCloud
+    # x-apple-reminder:// id. Reminders with no such id (Exchange/CalDAV) cannot
+    # be flagged — the EventKit "priority=1" proxy is not a real flag, so we
+    # refuse honestly rather than report a misleading success.
     rid = _rem_id(r)
-    if rid and osa_by_id_try(r["list_name"], rid, "set flagged of r to true"):
+    if not rid:
+        _refuse_flag_unsupported(a, r, "flag")
+    if osa_by_id_try(r["list_name"], rid, "set flagged of r to true"):
         if a.json:
             print(json.dumps({"status": "flagged", "id": a.id, "title": r["ZTITLE"]}))
         else:
             print(f"Flagged: {safe_display(r['ZTITLE'])}")
         return
+    _refuse_unsafe_title_fallback(r, "flag it", "Identifier-based writes failed")
 
-    if bridge_available() and r["ZCKIDENTIFIER"]:
-        data = {"action": "flag", "id": r["ZCKIDENTIFIER"]}
-        result = bridge_call(data)
-        if result and result.get("status") == "flagged":
-            if a.json:
-                print(json.dumps({"status": "flagged", "id": a.id, "title": r["ZTITLE"]}))
-            else:
-                print(f"Flagged: {safe_display(r['ZTITLE'])}")
-            return
-    if not rid:
-        _refuse_unsafe_title_fallback(r, "flag it", "The reminder has no stable identifier")
-    _refuse_unsafe_title_fallback(
-        r,
-        "flag it",
-        "Identifier-based writes failed",
-    )
 
 def cmd_unflag(a):
-    db = open_db()
-    r = q_reminder(db, a.id)
-    if not r:
-        print(f"Error: #{a.id} not found", file=sys.stderr)
-        sys.exit(1)
+    db, r = _resolve_reminder_for_write(a)
 
-    # AppleScript-first (see cmd_flag): only AppleScript can touch the real
-    # flagged column; bridge only toggles priority as a lossy proxy.
     rid = _rem_id(r)
-    if rid and osa_by_id_try(r["list_name"], rid, "set flagged of r to false"):
+    if not rid:
+        _refuse_flag_unsupported(a, r, "unflag")
+    if osa_by_id_try(r["list_name"], rid, "set flagged of r to false"):
         if a.json:
             print(json.dumps({"status": "unflagged", "id": a.id, "title": r["ZTITLE"]}))
         else:
             print(f"Unflagged: {safe_display(r['ZTITLE'])}")
         return
-
-    if bridge_available() and r["ZCKIDENTIFIER"]:
-        data = {"action": "unflag", "id": r["ZCKIDENTIFIER"]}
-        result = bridge_call(data)
-        if result and result.get("status") == "unflagged":
-            if a.json:
-                print(json.dumps({"status": "unflagged", "id": a.id, "title": r["ZTITLE"]}))
-            else:
-                print(f"Unflagged: {safe_display(r['ZTITLE'])}")
-            return
-    if not rid:
-        _refuse_unsafe_title_fallback(r, "unflag it", "The reminder has no stable identifier")
-    _refuse_unsafe_title_fallback(
-        r,
-        "unflag it",
-        "Identifier-based writes failed",
-    )
+    _refuse_unsafe_title_fallback(r, "unflag it", "Identifier-based writes failed")
 
 def cmd_upcoming(a):
     days = getattr(a, "days", None)
@@ -6411,56 +7572,133 @@ def cmd_upcoming(a):
     if days < 1 or days > 3650:
         print("Error: upcoming days must be between 1 and 3650.", file=sys.stderr)
         sys.exit(1)
-    db = open_db()
-    items = q_upcoming(db, days=days)
-    pks = [i["Z_PK"] for i in items]
-    sc, ht = preload_extras(db, pks)
+    if not _is_multi_account_mode(a):
+        db = open_db()
+        items = q_upcoming(db, days=days)
+        pks = [i["Z_PK"] for i in items]
+        sc, ht = preload_extras(db, pks)
+        if a.json:
+            print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+            return
+        if getattr(a, 'format', None) == 'table':
+            print(fmt_table(reminders_to_table_data(items, db)))
+            return
+        if not items:
+            print(f"Nothing due in the next {days} days")
+            return
+        print(C.bold(f"Upcoming ({days} days):"))
+        groups = {}
+        for i in items:
+            dt = ts(row_effective_due(i))
+            day_key = dt.strftime("%Y-%m-%d")
+            day_label = dt.strftime("%A, %b %d")
+            today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            if dt.date() == today.date():
+                day_label = "Today"
+            elif dt.date() == (today + timedelta(days=1)).date():
+                day_label = "Tomorrow"
+            groups.setdefault((day_key, day_label), []).append(i)
+        for (day_key, day_label), day_items in sorted(groups.items()):
+            print(f"\n  {C.bold(day_label)}:")
+            for i in day_items:
+                print(fmt(i, db, indent="    ", _sc=sc, _ht=ht))
+        print(f"\n{len(items)} upcoming")
+        return
+    scope = resolve_account_scope(a)
+    multi = len(scope) > 1
     if a.json:
-        print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+        dicts = gather_reminder_dicts(scope, lambda db: q_upcoming(db, days=days))
+        print(json.dumps(dicts, indent=2))
         return
     if getattr(a, 'format', None) == 'table':
-        print(fmt_table(reminders_to_table_data(items, db)))
+        print(fmt_table(gather_table_rows(scope, lambda db: q_upcoming(db, days=days))))
         return
-    if not items:
+    # groups: {(day_key, day_label): [(acct_name_or_None, rendered_line)]}
+    groups = {}
+    total = 0
+    with iter_account_dbs(scope) as account_dbs:
+        for acct, db in account_dbs:
+            items = q_upcoming(db, days=days)
+            pks = [i["Z_PK"] for i in items]
+            sc, ht = preload_extras(db, pks)
+            for i in items:
+                dt = ts(row_effective_due(i))
+                day_key = dt.strftime("%Y-%m-%d")
+                day_label = dt.strftime("%A, %b %d")
+                today_dt = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+                if dt.date() == today_dt.date():
+                    day_label = "Today"
+                elif dt.date() == (today_dt + timedelta(days=1)).date():
+                    day_label = "Tomorrow"
+                line = fmt(i, db, indent="    ", _sc=sc, _ht=ht)
+                groups.setdefault((day_key, day_label), []).append(
+                    (acct.name if multi else None, line)
+                )
+                total += 1
+    if not total:
         print(f"Nothing due in the next {days} days")
         return
     print(C.bold(f"Upcoming ({days} days):"))
-    # Group by day
-    groups = {}
-    for i in items:
-        dt = ts(row_effective_due(i))
-        day_key = dt.strftime("%Y-%m-%d")
-        day_label = dt.strftime("%A, %b %d")
-        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        if dt.date() == today.date():
-            day_label = "Today"
-        elif dt.date() == (today + timedelta(days=1)).date():
-            day_label = "Tomorrow"
-        groups.setdefault((day_key, day_label), []).append(i)
-    for (day_key, day_label), day_items in sorted(groups.items()):
+    for (day_key, day_label), entries in sorted(groups.items()):
         print(f"\n  {C.bold(day_label)}:")
-        for i in day_items:
-            print(fmt(i, db, indent="    ", _sc=sc, _ht=ht))
-    print(f"\n{len(items)} upcoming")
+        last_acct = None
+        for acct_name, line in entries:
+            if acct_name and acct_name != last_acct:
+                print(f"\n    {C.bold(acct_name)}")
+                last_acct = acct_name
+            print(line)
+    print(f"\n{total} upcoming")
+
 
 def cmd_overdue(a):
-    db = open_db()
-    items = q_overdue(db)
-    pks = [i["Z_PK"] for i in items]
-    sc, ht = preload_extras(db, pks)
+    if not _is_multi_account_mode(a):
+        db = open_db()
+        items = q_overdue(db)
+        pks = [i["Z_PK"] for i in items]
+        sc, ht = preload_extras(db, pks)
+        if a.json:
+            print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+            return
+        if getattr(a, 'format', None) == 'table':
+            print(fmt_table(reminders_to_table_data(items, db)))
+            return
+        if not items:
+            print("No overdue reminders")
+            return
+        print(C.red(C.bold(f"Overdue ({len(items)}):")))
+        for i in items:
+            print(fmt(i, db, verbose=getattr(a, 'verbose', False), indent="  ", _sc=sc, _ht=ht))
+        print(f"\n{len(items)} overdue")
+        return
+    scope = resolve_account_scope(a)
+    multi = len(scope) > 1
     if a.json:
-        print(json.dumps([to_dict(i, db, _sc=sc, _ht=ht) for i in items], indent=2))
+        dicts = gather_reminder_dicts(scope, q_overdue)
+        print(json.dumps(dicts, indent=2))
         return
     if getattr(a, 'format', None) == 'table':
-        print(fmt_table(reminders_to_table_data(items, db)))
+        print(fmt_table(gather_table_rows(scope, q_overdue)))
         return
-    if not items:
+    groups = []
+    with iter_account_dbs(scope) as account_dbs:
+        for acct, db in account_dbs:
+            items = q_overdue(db)
+            pks = [i["Z_PK"] for i in items]
+            sc, ht = preload_extras(db, pks)
+            lines = [fmt(i, db, verbose=getattr(a, 'verbose', False), indent="  ", _sc=sc, _ht=ht) for i in items]
+            if lines:
+                groups.append((acct.name if multi else None, lines))
+    total = sum(len(g[1]) for g in groups)
+    if not total:
         print("No overdue reminders")
         return
-    print(C.red(C.bold(f"Overdue ({len(items)}):")))
-    for i in items:
-        print(fmt(i, db, verbose=getattr(a, 'verbose', False), indent="  ", _sc=sc, _ht=ht))
-    print(f"\n{len(items)} overdue")
+    print(C.red(C.bold(f"Overdue ({total}):")))
+    for acct_name, lines in groups:
+        if acct_name:
+            print(f"\n  {C.bold(acct_name)}")
+        for line in lines:
+            print(line)
+    print(f"\n{total} overdue")
 
 def cmd_list_create(a):
     validate_list_appearance_args(a)
@@ -6520,7 +7758,7 @@ def cmd_list_edit(a):
         print("Error: pass at least one of --new-name, --color, --symbol, --emoji, --groceries, --standard, or --grocery-locale.", file=sys.stderr)
         sys.exit(1)
     require_private_metadata(a)
-    db = open_db()
+    db = _open_db_for_account(getattr(a, "account", None))
     list_ref = resolve_required_list_target_or_die(
         db,
         name=getattr(a, "name", None),
@@ -6547,7 +7785,7 @@ def _cmd_list_pin_state(a, pinned):
         print("Error: pass a list/smart-list name, --list-id, or --smart-list-id.", file=sys.stderr)
         sys.exit(1)
     require_private_metadata(a)
-    db = open_db()
+    db = _open_db_for_account(getattr(a, "account", None))
     smart_list_id = getattr(a, "smart_list_id", None)
     name = getattr(a, "name", None)
     if smart_list_id is not None:
@@ -6619,7 +7857,7 @@ def cmd_list_rename(a):
     if not new_name:
         print("Error: pass a new list name.", file=sys.stderr)
         sys.exit(1)
-    db = open_db()
+    db = _open_db_for_account(getattr(a, "account", None))
     list_ref = resolve_required_list_target_or_die(
         db,
         name=getattr(a, "name", None),
@@ -6642,7 +7880,7 @@ def cmd_list_rename(a):
         sys.exit(1)
 
 def cmd_list_delete(a):
-    db = open_db()
+    db = _open_db_for_account(getattr(a, "account", None))
     list_ref = resolve_required_list_target_or_die(
         db,
         name=getattr(a, "name", None),
@@ -6672,7 +7910,20 @@ def cmd_list_delete(a):
         sys.exit(1)
 
 def cmd_export(a):
-    db = open_db()
+    # export targets a single account. If an "all-accounts" scope is active via
+    # REMCTL_ACCOUNT_SCOPE or config accountScope, refuse rather than silently
+    # exporting only the default account. (The --all-accounts flag is already
+    # rejected by argparse for this command.)
+    scope = resolve_account_scope(a)
+    if len(scope) > 1:
+        print(
+            "Error: export targets a single account, but the active scope spans "
+            f"{len(scope)} accounts ({', '.join(ac.name for ac in scope)}). "
+            f"Re-run with --account NAME, e.g. `remctl export --account {scope[0].name}`.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    db = _open_db_for_account(getattr(a, "account", None) or (scope[0].name if scope else None))
     list_name = getattr(a, "list", None)
     list_id = getattr(a, "list_id", None)
     if list_name or list_id is not None:
@@ -6742,6 +7993,7 @@ def cmd_import(a):
         aa.url = item.get("url")
         aa.recurrence = item.get("recurrence")
         aa.alarm = item.get("alarm")
+        aa.account = getattr(a, "account", None)
         aa.json = False
 
         try:
@@ -7762,7 +9014,7 @@ def gather_doctor_checks():
             "database",
             "ok" if db_path else "fail",
             str(db_path) if db_path else "No Reminders database found",
-            None if db_path else "Enable iCloud Reminders and open Reminders.app once, or run remctl onboard.",
+            None if db_path else "Enable iCloud Reminders and open Reminders.app once, or run remctl onboard. Set REMCTL_DB to pin a specific database file.",
         )
 
     cli_path = current_cli_path()
@@ -7825,6 +9077,79 @@ def gather_doctor_checks():
         add("completion", "warn", f"Unsupported shell '{shell}'", "Run remctl setup --shell zsh|bash|fish.")
 
     return checks
+
+
+def cmd_accounts(a):
+    """List all discovered Reminders accounts."""
+    accounts = discover_accounts(force_refresh=True)
+    if getattr(a, "json", False):
+        print(json.dumps([
+            {"name": acct.name, "type": acct.type, "storePath": str(acct.store_path)}
+            for acct in accounts
+        ], indent=2))
+        return
+    if not accounts:
+        print("No Reminders accounts found.")
+        return
+    default_name = accounts[0].name if accounts else None
+    print(C.bold("Reminders Accounts:"))
+    for acct in accounts:
+        is_default = " (default)" if acct.name == default_name else ""
+        print(f"  {C.bold(acct.name)}{C.dim(is_default)}  {C.dim(acct.type)}")
+    print(f"\n{len(accounts)} account{'s' if len(accounts) != 1 else ''}")
+
+
+CONFIG_KEYS = {
+    "accountScope": "Default account scope: 'all', an account name, or '' for the auto-detected default",
+    "storeDir":     "Override the Reminders Stores directory (equivalent to REMCTL_STORE_DIR)",
+    "dbPath":       "Pin a specific Reminders database file — full path (equivalent to REMCTL_DB)",
+}
+
+
+def cmd_config(a):
+    """Get or set remctl configuration values."""
+    cfg = load_config()
+    if getattr(a, "key", None) is None:
+        # Show all config
+        if getattr(a, "json", False):
+            print(json.dumps(cfg, indent=2))
+            return
+        if not cfg or all(not v for v in cfg.values()):
+            print("No configuration set.")
+            print(f"Config file: {CONFIG_FILE}")
+            print(f"\nSupported keys:")
+            for k, desc in CONFIG_KEYS.items():
+                print(f"  {k}: {desc}")
+        else:
+            for k, v in cfg.items():
+                if v:
+                    print(f"  {k}: {v}")
+        return
+    key = a.key
+    if getattr(a, "value", None) is None:
+        # Get a single key
+        val = cfg.get(key)
+        if not val:
+            print("(not set)")
+        else:
+            print(val if not getattr(a, "json", False) else json.dumps({key: val}))
+        return
+    # Set a key — warn on unrecognised keys
+    if key not in CONFIG_KEYS:
+        known = ", ".join(CONFIG_KEYS)
+        print(f"Warning: '{key}' is not a recognised config key. Known keys: {known}", file=sys.stderr)
+    value = a.value
+    # Clear the key when value is empty string
+    if value == "":
+        cfg.pop(key, None)
+    else:
+        cfg[key] = value
+    save_config(cfg)
+    if not getattr(a, "json", False):
+        if value == "":
+            print(f"Cleared {key}")
+        else:
+            print(f"Set {key} = {value}")
 
 
 def cmd_doctor(a):
@@ -7979,7 +9304,10 @@ def format_command_columns(commands, width=88):
 
 
 def first_command_token(argv):
-    skip_value_for = {"--format"}
+    # Flags that consume the next token as their value
+    skip_value_for = {"--format", "--account"}
+    # Flags with inline values (--flag=value form)
+    skip_prefix_for = ("--format=", "--account=")
     iterator = iter(argv)
     for token in iterator:
         if token in {"-h", "--help", "--version"}:
@@ -7987,9 +9315,9 @@ def first_command_token(argv):
         if token in skip_value_for:
             next(iterator, None)
             continue
-        if token.startswith("--format="):
+        if any(token.startswith(p) for p in skip_prefix_for):
             continue
-        if token == "--no-color":
+        if token in {"--no-color", "--all-accounts"}:
             continue
         if token.startswith("-"):
             continue
@@ -8037,6 +9365,10 @@ def main():
     p.add_argument("--no-color", action="store_true", help="Disable color output")
     p.add_argument("--format", choices=["plain", "table", "json"], default="plain",
                    help="Output format")
+    p.add_argument("--account", dest="account", metavar="NAME",
+                   help="Target a specific Reminders account (can also be placed after the command)")
+    p.add_argument("--all-accounts", dest="all_accounts", action="store_true",
+                   help="Read from all connected Reminders accounts")
 
     sub = p.add_subparsers(dest="cmd", metavar="command")
 
@@ -8050,13 +9382,72 @@ def main():
             help="Output format for this read command",
         )
     def vb(c): c.add_argument("-v", "--verbose", action="store_true")
+    def account_scope(c):
+        """Add --all-accounts and --account flags for multi-account list/search commands."""
+        c.add_argument("--all-accounts", dest="all_accounts", action="store_true",
+                       default=argparse.SUPPRESS,
+                       help="Read from all connected Reminders accounts")
+        c.add_argument("--account", dest="account", metavar="NAME",
+                       default=argparse.SUPPRESS,
+                       help="Filter to a specific account. "
+                            "Use 'remctl accounts' to see available accounts.")
+
+    def acct(c):
+        """Add only --account NAME, for single-target commands that operate on one
+        account at a time and do NOT aggregate or scan across accounts (export,
+        smart-lists, templates, sharees, link, list-*/smart-list-*/template-* writes).
+        --all-accounts is intentionally not offered here so it can't be silently ignored."""
+        c.add_argument("--account", dest="account", metavar="NAME",
+                       default=argparse.SUPPRESS,
+                       help="Account to look up in (required when the same list name or "
+                            "reminder ID exists in multiple active accounts)")
+
+    def acct_scan(c):
+        """Add --account NAME and --all-accounts, for single-item commands that
+        resolve their target by scanning the active account scope (done, undone,
+        edit, delete, flag, unflag, info, subtasks, show, open). --all-accounts
+        means "search every connected account to resolve the target", and is
+        honored via _resolve_reminder_for_write / resolve_list_ref_across."""
+        c.add_argument("--account", dest="account", metavar="NAME",
+                       default=argparse.SUPPRESS,
+                       help="Account to look up in (required when the same list name or "
+                            "reminder ID exists in multiple active accounts)")
+        c.add_argument("--all-accounts", dest="all_accounts", action="store_true",
+                       default=argparse.SUPPRESS,
+                       help="Search every connected account to resolve the target")
+
+    # --- Accounts / config ---
+    c = sub.add_parser("accounts", help="List connected Reminders accounts"); js(c)
+
+    c = sub.add_parser(
+        "config",
+        help="Get or set remctl configuration",
+        description="Get or set persistent remctl configuration values.",
+        epilog=(
+            "Supported keys:\n"
+            "  accountScope   Default account scope: 'all', an account name, or '' to reset\n"
+            "  storeDir       Override the Reminders Stores directory (like REMCTL_STORE_DIR)\n"
+            "  dbPath         Pin a specific database file — full path (like REMCTL_DB)\n"
+            "\n"
+            "Examples:\n"
+            "  remctl config                          # show current settings\n"
+            "  remctl config accountScope             # get one key\n"
+            "  remctl config accountScope all         # set a key\n"
+            "  remctl config accountScope \"\"          # clear a key\n"
+            "  remctl config dbPath /path/to/Data-XXXX.sqlite\n"
+        ),
+        formatter_class=HelpFormatter,
+    )
+    c.add_argument("key", nargs="?", help="Config key (accountScope, storeDir, dbPath)")
+    c.add_argument("value", nargs="?", help="Value to set; pass '' to clear")
+    js(c)
 
     # --- Existing commands ---
-    c = sub.add_parser("lists", help="List all iCloud reminder lists"); js(c); display_format(c)
+    c = sub.add_parser("lists", help="List all Reminders lists"); js(c); display_format(c); account_scope(c)
 
-    c = sub.add_parser("smart-lists", help="Inspect Reminders smart lists"); js(c)
+    c = sub.add_parser("smart-lists", help="Inspect Reminders smart lists"); js(c); account_scope(c)
 
-    c = sub.add_parser("templates", help="Inspect saved Reminders templates"); js(c)
+    c = sub.add_parser("templates", help="Inspect saved Reminders templates"); js(c); account_scope(c)
 
     c = sub.add_parser(
         "template-info",
@@ -8073,13 +9464,13 @@ def main():
     )
     c.add_argument("name", nargs="?", help="Template name")
     c.add_argument("--template-id", type=int, help="Read by numeric template ID from templates")
-    js(c)
+    js(c); acct_scan(c)
 
     c = sub.add_parser("show", help="Show reminders in a list (grouped by section)")
     c.add_argument("list", nargs="?", help="List name")
     c.add_argument("--list-id", type=int, help="Show a list by stable numeric ID")
     c.add_argument("--completed", action="store_true", help="Include completed")
-    vb(c); js(c); display_format(c)
+    vb(c); js(c); display_format(c); acct_scan(c)
 
     c = sub.add_parser(
         "add",
@@ -8116,6 +9507,9 @@ def main():
     )
     c.add_argument("title"); c.add_argument("-l", "--list")
     c.add_argument("--list-id", type=int, help="Create in a list by stable numeric ID")
+    c.add_argument("--account", dest="account", metavar="NAME",
+                   default=argparse.SUPPRESS,
+                   help="Target account for this reminder (required when list name is ambiguous across accounts)")
     c.add_argument("-n", "--notes"); c.add_argument("-d", "--due", help="Due date; date-only forms create all-day reminders, explicit times create timed reminders")
     c.add_argument("-p", "--priority", help="high, medium, low")
     c.add_argument("-f", "--flag", action="store_true")
@@ -8137,8 +9531,8 @@ def main():
     c.add_argument("--early-reminder", help="Private metadata: Early Reminder before due date, e.g. 15m, 1h, 2d, 1w, 1mo, or clear")
     js(c)
 
-    c = sub.add_parser("done", help="Complete a reminder"); c.add_argument("id", type=int); js(c)
-    c = sub.add_parser("undone", help="Uncomplete a reminder"); c.add_argument("id", type=int); js(c)
+    c = sub.add_parser("done", help="Complete a reminder"); c.add_argument("id", type=int); js(c); acct_scan(c)
+    c = sub.add_parser("undone", help="Uncomplete a reminder"); c.add_argument("id", type=int); js(c); acct_scan(c)
 
     c = sub.add_parser(
         "edit",
@@ -8200,30 +9594,33 @@ def main():
     c.add_argument("--radius", type=float, default=100.0, help="Guarded metadata: location alarm radius in meters")
     c.add_argument("--proximity", choices=["arriving", "leaving"], default="arriving", help="Guarded metadata: location alarm trigger direction")
     c.add_argument("--address", help=argparse.SUPPRESS)
-    js(c)
+    js(c); acct_scan(c)
 
     c = sub.add_parser("delete", help="Delete a reminder")
-    c.add_argument("id", type=int); c.add_argument("--force", action="store_true"); js(c)
+    c.add_argument("id", type=int); c.add_argument("--force", action="store_true"); js(c); acct_scan(c)
 
     c = sub.add_parser("search", help="Search reminders")
     c.add_argument("query"); c.add_argument("--completed", action="store_true"); vb(c); js(c)
-    display_format(c)
+    display_format(c); account_scope(c)
 
     c = sub.add_parser("today", help="Due today + overdue")
     c.add_argument("--no-overdue", action="store_true"); vb(c); js(c); display_format(c)
+    account_scope(c)
 
     c = sub.add_parser("flagged", help="Flagged reminders"); vb(c); js(c); display_format(c)
+    account_scope(c)
 
     c = sub.add_parser("urgent", help="Urgent reminders"); vb(c); js(c); display_format(c)
+    account_scope(c)
 
-    c = sub.add_parser("tags", help="List all hashtag labels"); js(c)
+    c = sub.add_parser("tags", help="List all hashtag labels"); js(c); account_scope(c)
 
     c = sub.add_parser("subtasks", help="Show subtasks of a reminder")
-    c.add_argument("id", type=int); vb(c); js(c)
+    c.add_argument("id", type=int); vb(c); js(c); acct_scan(c)
 
-    c = sub.add_parser("info", help="Full detail view"); c.add_argument("id", type=int); js(c)
+    c = sub.add_parser("info", help="Full detail view"); c.add_argument("id", type=int); js(c); acct_scan(c)
 
-    c = sub.add_parser("sections", help="Show sections across lists"); js(c)
+    c = sub.add_parser("sections", help="Show sections across lists"); js(c); account_scope(c)
 
     c = sub.add_parser(
         "sharees",
@@ -8242,28 +9639,30 @@ def main():
     )
     c.add_argument("list", nargs="?", help="Shared list name")
     c.add_argument("--list-id", type=int, help="Shared list numeric ID")
-    js(c)
+    js(c); acct_scan(c)
 
-    c = sub.add_parser("stats", help="Statistics"); js(c)
+    c = sub.add_parser("stats", help="Statistics"); js(c); account_scope(c)
 
     c = sub.add_parser("link", help="Get deep link(s) for reminders")
     c.add_argument("ids", type=int, nargs="*", help="Reminder IDs")
     c.add_argument("-l", "--list", help="Get links for all active reminders in a list")
     c.add_argument("--list-id", type=int, help="Get links for all active reminders in a list by stable numeric ID")
-    c.add_argument("--completed", action="store_true"); js(c)
+    c.add_argument("--completed", action="store_true"); js(c); acct_scan(c)
 
     c = sub.add_parser("open", help="Open reminder in Reminders.app (or just open the app)")
     c.add_argument("id", type=int, nargs="?", default=None, help="Reminder ID (opens specific reminder via deep link)")
+    acct_scan(c)
 
     # --- New commands ---
-    c = sub.add_parser("flag", help="Flag a reminder"); c.add_argument("id", type=int); js(c)
-    c = sub.add_parser("unflag", help="Unflag a reminder"); c.add_argument("id", type=int); js(c)
+    c = sub.add_parser("flag", help="Flag a reminder"); c.add_argument("id", type=int); js(c); acct_scan(c)
+    c = sub.add_parser("unflag", help="Unflag a reminder"); c.add_argument("id", type=int); js(c); acct_scan(c)
 
     c = sub.add_parser("upcoming", help="Show reminders due in next N days (default 7)")
     c.add_argument("days", type=int, nargs="?", default=7, help="Number of days to look ahead")
-    vb(c); js(c); display_format(c)
+    vb(c); js(c); display_format(c); account_scope(c)
 
     c = sub.add_parser("overdue", help="Show all overdue reminders"); vb(c); js(c); display_format(c)
+    account_scope(c)
 
     c = sub.add_parser("list-symbols", help="List official Reminders list symbols")
     c.add_argument("--html", nargs="?", const="", metavar="PATH", help="Write a standalone HTML preview contact sheet")
@@ -8308,7 +9707,7 @@ def main():
     c.add_argument("--symbol", help="Official Reminders list symbol name; run list-symbols")
     c.add_argument("--emoji", help="Private Reminders list emoji badge")
     add_smart_list_filter_arguments(c)
-    js(c)
+    js(c); acct(c)
 
     c = sub.add_parser(
         "smart-list-edit",
@@ -8333,7 +9732,7 @@ def main():
     c.add_argument("--symbol", help="Official Reminders list symbol name; run list-symbols")
     c.add_argument("--emoji", help="Private Reminders list emoji badge")
     add_smart_list_filter_arguments(c)
-    js(c)
+    js(c); acct(c)
 
     c = sub.add_parser(
         "smart-list-delete",
@@ -8347,7 +9746,7 @@ def main():
     c.add_argument("--smart-list-id", type=int, help="Delete by numeric smart-list ID from smart-lists")
     c.add_argument("--private", action="store_true", help="Required for private ReminderKit smart-list deletion")
     c.add_argument("--force", action="store_true", help="Skip confirmation prompt")
-    js(c)
+    js(c); acct(c)
 
     c = sub.add_parser(
         "template-create",
@@ -8371,7 +9770,7 @@ def main():
     c.add_argument("--from-list-id", type=int, help="Source list numeric ID")
     c.add_argument("--include-completed", action="store_true", help="Include completed reminders in the saved template")
     c.add_argument("--private", action="store_true", help="Required for private ReminderKit template creation")
-    js(c)
+    js(c); acct(c)
 
     c = sub.add_parser(
         "template-apply",
@@ -8390,7 +9789,7 @@ def main():
     c.add_argument("name", nargs="?", help="Template name")
     c.add_argument("--template-id", type=int, help="Apply by numeric template ID from templates")
     c.add_argument("--private", action="store_true", help="Required for private ReminderKit template application")
-    js(c)
+    js(c); acct(c)
 
     c = sub.add_parser(
         "template-delete",
@@ -8407,7 +9806,7 @@ def main():
     c.add_argument("--template-id", type=int, help="Delete by numeric template ID from templates")
     c.add_argument("--private", action="store_true", help="Required for private ReminderKit template deletion")
     c.add_argument("--force", action="store_true", help="Skip confirmation prompt")
-    js(c)
+    js(c); acct(c)
 
     c = sub.add_parser("list-edit", help="Edit private list appearance by name or ID")
     c.add_argument("name", nargs="?", help="List name to edit")
@@ -8420,42 +9819,42 @@ def main():
     c.add_argument("--standard", action="store_true", help="Convert a Groceries list back to a standard list")
     c.add_argument("--grocery-locale", help="Groceries locale identifier, e.g. en_US or it_IT")
     c.add_argument("--private", action="store_true", help="Required for list appearance and grocery metadata writes")
-    js(c)
+    js(c); acct(c)
 
     c = sub.add_parser("list-pin", help="Pin a list or smart list in Reminders.app")
     c.add_argument("name", nargs="?", help="List or smart-list name to pin")
     c.add_argument("--list-id", type=int, help="Pin a list by stable numeric ID")
     c.add_argument("--smart-list-id", type=int, help="Pin a smart list by stable numeric ID")
     c.add_argument("--private", action="store_true", help="Required for private ReminderKit list pinning")
-    js(c)
+    js(c); acct(c)
 
     c = sub.add_parser("list-unpin", help="Unpin a list or smart list in Reminders.app")
     c.add_argument("name", nargs="?", help="List or smart-list name to unpin")
     c.add_argument("--list-id", type=int, help="Unpin a list by stable numeric ID")
     c.add_argument("--smart-list-id", type=int, help="Unpin a smart list by stable numeric ID")
     c.add_argument("--private", action="store_true", help="Required for private ReminderKit list pinning")
-    js(c)
+    js(c); acct(c)
 
     c = sub.add_parser("list-rename", help="Rename a list (bridge only)")
     c.add_argument("name", nargs="?", help="List name to rename")
     c.add_argument("new_name", nargs="?", help="New list name")
     c.add_argument("--list-id", type=int, help="Rename a list by stable numeric ID")
     c.add_argument("--new-name", dest="new_name_option", help="New list name, useful with --list-id")
-    js(c)
+    js(c); acct(c)
 
     c = sub.add_parser("list-delete", help="Delete a list (bridge only)")
     c.add_argument("name", nargs="?", help="List name to delete")
     c.add_argument("--list-id", type=int, help="Delete a list by stable numeric ID")
-    c.add_argument("--force", action="store_true"); js(c)
+    c.add_argument("--force", action="store_true"); js(c); acct(c)
 
     c = sub.add_parser("export", help="Export reminders")
     c.add_argument("-l", "--list", help="Export only this list")
     c.add_argument("--list-id", type=int, help="Export only this list by stable numeric ID")
     c.add_argument("--format", dest="export_format", choices=["json", "csv"], default="json", help="Export format")
-    js(c)
+    js(c); acct(c)
 
     c = sub.add_parser("import", help="Import reminders from JSON file")
-    c.add_argument("file", help="Path to JSON file"); js(c)
+    c.add_argument("file", help="Path to JSON file"); js(c); acct(c)
 
     c = sub.add_parser(
         "onboard",
@@ -8564,6 +9963,25 @@ def main():
         print("Run `remctl <command> --help` for command-specific options.", file=sys.stderr)
         sys.exit(2)
     a = p.parse_args()
+
+    # Strictness: the global --account/--all-accounts flags are accepted before
+    # any command so they work in either position. Reject each flag for commands
+    # whose subparser does not define it — matching the error those commands give
+    # when the flag is placed after the subcommand, and ensuring a flag is never
+    # silently ignored (e.g. --all-accounts on export, which targets one account).
+    subparser = sub.choices.get(getattr(a, "cmd", None))
+    sub_opts = set()
+    if subparser:
+        for act in subparser._actions:
+            sub_opts.update(act.option_strings)
+    cmd_label = getattr(a, "cmd", None) or "(none)"
+    if getattr(a, "account", None) and "--account" not in sub_opts:
+        print(f"remctl: error: command {cmd_label!r} does not support --account", file=sys.stderr)
+        sys.exit(2)
+    if getattr(a, "all_accounts", False) and "--all-accounts" not in sub_opts:
+        print(f"remctl: error: command {cmd_label!r} does not support --all-accounts", file=sys.stderr)
+        sys.exit(2)
+
     command_format = getattr(a, "command_format", None)
     if command_format:
         a.format = command_format
@@ -8599,6 +10017,8 @@ def main():
 
     # Route to command handler
     cmds = {
+        "accounts": cmd_accounts,
+        "config": cmd_config,
         "lists": cmd_lists,
         "smart-lists": cmd_smart_lists,
         "templates": cmd_templates,

--- a/remctl-bridge.swift
+++ b/remctl-bridge.swift
@@ -10,6 +10,8 @@ struct Command: Decodable {
     let title: String?
     let newTitle: String?
     let list: String?
+    let calendarIdentifier: String?  // stable EKCalendar.calendarIdentifier; preferred over list name
+    let account: String?              // EKSource.title hint for disambiguating same-name lists
     let due: String?
     let priority: Int?
     let notes: String?
@@ -199,18 +201,44 @@ func findReminder(_ store: EKEventStore, id: String) -> EKReminder {
     return item
 }
 
-func findList(_ store: EKEventStore, name: String) -> EKCalendar {
-    guard let cal = store.calendars(for: .reminder).first(where: { $0.title == name }) else {
-        fail("List not found: \(name)")
+func sourceTypeName(_ type: EKSourceType?) -> String? {
+    guard let type = type else { return nil }
+    switch type {
+    case .local:       return "Local"
+    case .exchange:    return "Exchange"
+    case .calDAV:      return "CalDAV"
+    case .mobileMe:    return "MobileMe"
+    case .subscribed:  return "Subscribed"
+    case .birthdays:   return "Birthdays"
+    default:           return nil
     }
-    return cal
+}
+
+func findList(_ store: EKEventStore, calendarIdentifier: String? = nil, name: String? = nil, account: String? = nil) -> EKCalendar {
+    // Prefer stable calendarIdentifier
+    if let cid = calendarIdentifier, let cal = store.calendar(withIdentifier: cid) {
+        return cal
+    }
+    guard let name = name else { fail("findList: must provide calendarIdentifier or name") }
+    let candidates = store.calendars(for: .reminder).filter { $0.title == name }
+    if candidates.isEmpty { fail("List not found: \(name)") }
+    // If account hint given, prefer matching source
+    if let account = account {
+        let accountMatch = candidates.filter { $0.source?.title == account }
+        if accountMatch.count == 1 { return accountMatch[0] }
+        if accountMatch.count > 1 { fail("Ambiguous list '\(name)' in account '\(account)': \(accountMatch.count) matches") }
+        // account hint didn't match any source; fall through to single-candidate check
+    }
+    if candidates.count == 1 { return candidates[0] }
+    let sourceNames = candidates.compactMap { $0.source?.title }.joined(separator: ", ")
+    fail("Ambiguous list '\(name)': exists in multiple accounts (\(sourceNames)). Pass calendarIdentifier or account.")
 }
 
 func applyFields(_ reminder: EKReminder, _ cmd: Command, store: EKEventStore) {
     if let t = cmd.title { reminder.title = t }
 
-    if let list = cmd.list {
-        reminder.calendar = findList(store, name: list)
+    if cmd.calendarIdentifier != nil || cmd.list != nil {
+        reminder.calendar = findList(store, calendarIdentifier: cmd.calendarIdentifier, name: cmd.list, account: cmd.account)
     }
 
     // due: present string → set date, JSON null → clear.
@@ -365,8 +393,8 @@ case "create":
     guard let title = cmd.title, !title.isEmpty else { fail("title is required for create") }
     let reminder = EKReminder(eventStore: store)
     reminder.title = title
-    if let list = cmd.list {
-        reminder.calendar = findList(store, name: list)
+    if cmd.calendarIdentifier != nil || cmd.list != nil {
+        reminder.calendar = findList(store, calendarIdentifier: cmd.calendarIdentifier, name: cmd.list, account: cmd.account)
     } else {
         reminder.calendar = store.defaultCalendarForNewReminders()
     }
@@ -448,16 +476,63 @@ case "unflag":
         fail("Unflag failed: \(error.localizedDescription)")
     }
 
+case "find_reminder":
+    // Find a reminder by title within a specific calendar and return its calendarItemIdentifier.
+    // Used to obtain a stable EventKit identifier for reminders (e.g. Exchange) that have no
+    // ZCKIDENTIFIER in the CoreData store.
+    guard let calId = cmd.calendarIdentifier else { fail("find_reminder: calendarIdentifier required") }
+    guard let searchTitle = cmd.title else { fail("find_reminder: title required") }
+    guard let cal = store.calendar(withIdentifier: calId) else { fail("Calendar not found: \(calId)") }
+    let predicate = store.predicateForReminders(in: [cal])
+    let sem = DispatchSemaphore(value: 0)
+    var found: EKReminder? = nil
+    store.fetchReminders(matching: predicate) { items in
+        found = items?.first(where: { $0.title == searchTitle && !$0.isCompleted })
+               ?? items?.first(where: { $0.title == searchTitle })
+        sem.signal()
+    }
+    sem.wait()
+    guard let reminder = found else { fail("Reminder not found: \(searchTitle)") }
+    let result: [String: Any] = ["calendarItemIdentifier": reminder.calendarItemIdentifier]
+    if let data = try? JSONSerialization.data(withJSONObject: result),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+    }
+    exit(0)
+
+case "list_calendars":
+    let cals = store.calendars(for: .reminder).map { cal -> [String: Any] in
+        var entry: [String: Any] = [
+            "title":              cal.title,
+            "calendarIdentifier": cal.calendarIdentifier,
+        ]
+        if let sourceTitle = cal.source?.title { entry["sourceTitle"] = sourceTitle }
+        if let typeName = sourceTypeName(cal.source?.sourceType) { entry["sourceType"] = typeName }
+        return entry
+    }
+    if let data = try? JSONSerialization.data(withJSONObject: cals),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+    }
+    exit(0)
+
 case "create_list":
     guard let title = cmd.title, !title.isEmpty else { fail("title is required for create_list") }
     let cal = EKCalendar(for: .reminder, eventStore: store)
     cal.title = title
-    // Use the local/iCloud source for reminders
-    guard let source = store.sources.first(where: { $0.sourceType == .calDAV })
-            ?? store.sources.first(where: { $0.sourceType == .local }) else {
-        fail("No suitable calendar source found")
+    if let account = cmd.account {
+        guard let source = store.sources.first(where: { $0.title == account }) else {
+            fail("Account not found: \(account)")
+        }
+        cal.source = source
+    } else {
+        // Fallback: prefer calDAV (iCloud), then local
+        guard let source = store.sources.first(where: { $0.sourceType == .calDAV })
+                ?? store.sources.first(where: { $0.sourceType == .local }) else {
+            fail("No suitable calendar source found")
+        }
+        cal.source = source
     }
-    cal.source = source
     if let colorName = cmd.color, let cg = colorForName(colorName) {
         cal.cgColor = cg
     }
@@ -471,7 +546,7 @@ case "create_list":
 case "rename_list":
     guard let title = cmd.title else { fail("title is required for rename_list") }
     guard let newTitle = cmd.newTitle else { fail("newTitle is required for rename_list") }
-    let cal = findList(store, name: title)
+    let cal = findList(store, calendarIdentifier: cmd.calendarIdentifier, name: title, account: cmd.account)
     cal.title = newTitle
     do {
         try store.saveCalendar(cal, commit: true)
@@ -482,7 +557,7 @@ case "rename_list":
 
 case "delete_list":
     guard let title = cmd.title else { fail("title is required for delete_list") }
-    let cal = findList(store, name: title)
+    let cal = findList(store, calendarIdentifier: cmd.calendarIdentifier, name: title, account: cmd.account)
     do {
         try store.removeCalendar(cal, commit: true)
         output(["status": "deleted", "title": title])

--- a/remctl_runtime.py
+++ b/remctl_runtime.py
@@ -30,6 +30,11 @@ def resolve_store_dir() -> Path:
     return Path.home() / DEFAULT_STORE_SUBPATH
 
 
+def resolve_db_override() -> "Path | None":
+    override = os.environ.get("REMCTL_DB")
+    return Path(override).expanduser() if override else None
+
+
 def resolve_config_dir(app_name: str = "remctl") -> Path:
     override = os.environ.get("REMCTL_CONFIG_DIR")
     if override:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,40 @@ class CliTests(unittest.TestCase):
     def setUpClass(cls):
         cls.remctl = load_module("remctl_cli_test", "remctl")
 
+    def setUp(self):
+        """Isolate every test from the developer's real config file, the
+        REMCTL_ACCOUNT_SCOPE environment variable, and module-level caches so
+        account-scope behavior is deterministic regardless of local state."""
+        # Save module globals that scope/config logic mutates.
+        self._saved_store_dir = self.remctl.STORE_DIR
+        self._saved_db_override = self.remctl.DB_OVERRIDE
+        self._saved_config_file = self.remctl.CONFIG_FILE
+        self._saved_account_scope_env = os.environ.pop("REMCTL_ACCOUNT_SCOPE", None)
+        self._saved_db_env = os.environ.pop("REMCTL_DB", None)
+        self._saved_store_env = os.environ.pop("REMCTL_STORE_DIR", None)
+        # Point config at a path that does not exist so load_config() returns {}.
+        self.remctl.CONFIG_FILE = Path("/nonexistent/remctl-test-config.json")
+        self.remctl._ACCOUNT_CACHE = None
+        try:
+            self.remctl._REMINDER_COLUMN_CACHE.clear()
+        except Exception:
+            pass
+
+    def tearDown(self):
+        self.remctl.STORE_DIR = self._saved_store_dir
+        self.remctl.DB_OVERRIDE = self._saved_db_override
+        self.remctl.CONFIG_FILE = self._saved_config_file
+        self.remctl._ACCOUNT_CACHE = None
+        for var, val in (
+            ("REMCTL_ACCOUNT_SCOPE", self._saved_account_scope_env),
+            ("REMCTL_DB", self._saved_db_env),
+            ("REMCTL_STORE_DIR", self._saved_store_env),
+        ):
+            if val is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = val
+
     def test_parse_alarm_normalizes_relative_and_absolute_values(self):
         self.assertEqual(self.remctl.parse_alarm("15m"), "-15m")
         self.assertEqual(self.remctl.parse_alarm("2h"), "-2h")
@@ -385,6 +419,7 @@ class CliTests(unittest.TestCase):
         try:
             with (
                 mock.patch.object(self.remctl, "open_db", return_value=db),
+                mock.patch.object(self.remctl, "load_config", return_value={}),
                 contextlib.redirect_stdout(io.StringIO()) as stdout,
             ):
                 self.remctl.cmd_lists(SimpleNamespace(json=True))
@@ -408,6 +443,7 @@ class CliTests(unittest.TestCase):
         try:
             with (
                 mock.patch.object(self.remctl, "open_db", return_value=db),
+                mock.patch.object(self.remctl, "load_config", return_value={}),
                 contextlib.redirect_stdout(io.StringIO()) as stdout,
             ):
                 self.remctl.cmd_lists(SimpleNamespace(json=False, format=None))
@@ -715,7 +751,7 @@ class CliTests(unittest.TestCase):
         self.assertIn("unknown command: 'symbols'", output)
         self.assertIn("Did you mean: remctl list-symbols", output)
         self.assertIn("Available commands:", output)
-        self.assertIn("  add,", output)
+        self.assertIn("add,", output)
         self.assertNotIn("choose from", output)
 
     def test_read_command_accepts_format_after_subcommand(self):
@@ -4291,6 +4327,2747 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["earlyReminder"]["unitCode"], 0)
         self.assertEqual(payload["earlyReminder"]["count"], -15)
         self.assertEqual(payload["earlyReminders"][0]["identifier"], "DELTA-1")
+
+    # ── Multi-Account Tests ──────────────────────────────────────────────────
+
+    # ── Helpers ──────────────────────────────────────────────────────────────
+
+    def _make_account_db(self, name, account_type, lists, reminders=None):
+        """Build a minimal in-memory SQLite db representing one Reminders account store."""
+        db = sqlite3.connect(":memory:")
+        db.row_factory = sqlite3.Row
+
+        # ZREMCDBASELIST
+        db.execute(
+            "CREATE TABLE ZREMCDBASELIST ("
+            "Z_PK INTEGER PRIMARY KEY, ZNAME TEXT, ZCKIDENTIFIER TEXT, "
+            "ZMARKEDFORDELETION INTEGER, Z_ENT INTEGER, "
+            "ZBADGEEMBLEM TEXT, ZCOLOR BLOB, "
+            "ZISPINNEDBYCURRENTUSER INTEGER, ZPINNEDDATE REAL, "
+            "ZSHOULDCATEGORIZEGROCERYITEMS INTEGER, ZSHOULDAUTOCATEGORIZEITEMS INTEGER, "
+            "ZSHOULDSUGGESTCONVERSIONTOGROCERYLIST INTEGER, ZGROCERYLOCALEID TEXT, "
+            "ZAUTOCATEGORIZATIONLOCALCORRECTIONSASDATA_LENGTH INTEGER)"
+        )
+        for pk, lname, ckid in lists:
+            db.execute(
+                "INSERT INTO ZREMCDBASELIST "
+                "(Z_PK, ZNAME, ZCKIDENTIFIER, ZMARKEDFORDELETION, Z_ENT, "
+                "ZBADGEEMBLEM, ZCOLOR, ZISPINNEDBYCURRENTUSER, ZPINNEDDATE, "
+                "ZSHOULDCATEGORIZEGROCERYITEMS, ZSHOULDAUTOCATEGORIZEITEMS, "
+                "ZSHOULDSUGGESTCONVERSIONTOGROCERYLIST, ZGROCERYLOCALEID) "
+                "VALUES (?, ?, ?, 0, 3, NULL, NULL, 0, NULL, 0, 0, 0, NULL)",
+                (pk, lname, ckid),
+            )
+
+        # ZREMCDBASESECTION
+        db.execute(
+            "CREATE TABLE ZREMCDBASESECTION ("
+            "Z_PK INTEGER PRIMARY KEY, ZDISPLAYNAME TEXT, ZLIST INTEGER, "
+            "ZTEMPLATE INTEGER, "
+            "ZCKIDENTIFIER TEXT, ZMARKEDFORDELETION INTEGER)"
+        )
+
+        # ZREMCDTEMPLATE / ZREMCDSAVEDREMINDER — empty, so template lookups
+        # resolve to "not found" rather than raising on a missing table.
+        db.execute(
+            "CREATE TABLE ZREMCDTEMPLATE ("
+            "Z_PK INTEGER PRIMARY KEY, ZNAME TEXT, ZCKIDENTIFIER TEXT, "
+            "ZCREATIONDATE REAL, ZLASTMODIFIEDDATE REAL, "
+            "ZPUBLICLINKCREATIONDATE REAL, ZPUBLICLINKEXPIRATIONDATE REAL, "
+            "ZPUBLICLINKLASTMODIFIEDDATE REAL, ZMARKEDFORDELETION INTEGER)"
+        )
+        db.execute(
+            "CREATE TABLE ZREMCDSAVEDREMINDER ("
+            "Z_PK INTEGER PRIMARY KEY, ZTITLE TEXT, ZTEMPLATE INTEGER, "
+            "ZMARKEDFORDELETION INTEGER)"
+        )
+
+        # ZREMCDREMINDER
+        db.execute(
+            "CREATE TABLE ZREMCDREMINDER ("
+            "Z_PK INTEGER PRIMARY KEY, ZTITLE TEXT, ZNOTES TEXT, ZCOMPLETED INTEGER, "
+            "ZFLAGGED INTEGER, ZPRIORITY INTEGER, ZISURGENTSTATEENABLEDFORCURRENTUSER INTEGER, "
+            "ZDUEDATEDELTAALERTSDATA TEXT, ZDUEDATE REAL, ZDISPLAYDATEDATE REAL, ZALLDAY INTEGER, "
+            "ZCOMPLETIONDATE REAL, ZCREATIONDATE REAL, ZPARENTREMINDER INTEGER, ZLIST INTEGER, "
+            "ZICSURL TEXT, ZCKIDENTIFIER TEXT, ZACCOUNT INTEGER, ZMARKEDFORDELETION INTEGER)"
+        )
+
+        # ZREMCDOBJECT — used for account entity row, recurrence objects, hashtag joins,
+        # rich link lookups, alarm lookups, attachment lookups, assignment lookups
+        db.execute(
+            "CREATE TABLE ZREMCDOBJECT ("
+            "Z_PK INTEGER, Z_ENT INTEGER, ZNAME TEXT, "
+            "ZREMINDER INTEGER, ZREMINDER1 INTEGER, ZREMINDER2 INTEGER, "
+            "ZREMINDER3 INTEGER, ZREMINDER4 INTEGER, "
+            "ZHASHTAGLABEL INTEGER, ZURL TEXT, ZFILENAME TEXT, "
+            "ZTRIGGER INTEGER, ZTIMEINTERVAL REAL, ZDATECOMPONENTSDATA BLOB, "
+            "ZTITLE TEXT, ZLATITUDE REAL, ZLONGITUDE REAL, ZRADIUS REAL, "
+            "ZADDRESS TEXT, ZPROXIMITY INTEGER, "
+            "ZCKIDENTIFIER TEXT, ZDISPLAYNAME TEXT, ZFIRSTNAME TEXT, ZLASTNAME TEXT, "
+            "ZADDRESS1 TEXT, ZASSIGNEDDATE REAL, ZLIST INTEGER, "
+            "ZCKASSIGNEEIDENTIFIER TEXT, ZCKORIGINATORIDENTIFIER TEXT, "
+            "ZASSIGNEE INTEGER, ZORIGINATOR INTEGER, ZSTATUS INTEGER, ZACCESSLEVEL INTEGER, "
+            "ZMARKEDFORDELETION INTEGER, ZFREQUENCY INTEGER, ZINTERVAL INTEGER, "
+            "ZOCCURRENCECOUNT INTEGER, ZENDDATE REAL, ZDAYSOFTHEWEEK BLOB, "
+            "ZDAYSOFTHEMONTH BLOB, ZMONTHSOFTHEYEAR BLOB, ZDAYSOFTHEYEAR BLOB, "
+            "ZWEEKSOFTHEYEAR BLOB, ZSETPOSITIONS BLOB)"
+        )
+
+        # Z_PRIMARYKEY — needed for _store_account_info
+        db.execute(
+            "CREATE TABLE Z_PRIMARYKEY (Z_NAME TEXT, Z_ENT INTEGER, Z_MAX INTEGER)"
+        )
+        db.execute(
+            "INSERT INTO Z_PRIMARYKEY (Z_NAME, Z_ENT, Z_MAX) VALUES ('REMCDAccount', 14, 1)"
+        )
+
+        # Insert account object row
+        db.execute(
+            "INSERT INTO ZREMCDOBJECT (Z_PK, Z_ENT, ZNAME, ZMARKEDFORDELETION) VALUES (1, 14, ?, 0)",
+            (name,),
+        )
+
+        # ZREMCDREPLICAMANAGER — determines account type
+        db.execute(
+            "CREATE TABLE ZREMCDREPLICAMANAGER (Z_PK INTEGER, Z_ENT INTEGER, ZIDENTIFIER TEXT)"
+        )
+        if account_type == "Exchange":
+            identifier = "exchange-uuid/com.apple.exchangesync.exchangesyncd"
+        else:
+            identifier = "icloud-uuid/com.apple.reminders"
+        db.execute(
+            "INSERT INTO ZREMCDREPLICAMANAGER (Z_PK, Z_ENT, ZIDENTIFIER) VALUES (1, 15, ?)",
+            (identifier,),
+        )
+
+        # ZREMCDHASHTAGLABEL — needed by q_hashtags
+        db.execute(
+            "CREATE TABLE ZREMCDHASHTAGLABEL (Z_PK INTEGER PRIMARY KEY, ZNAME TEXT, ZREMINDER3 INTEGER)"
+        )
+
+        # Insert reminders if provided
+        if reminders:
+            for rem in reminders:
+                db.execute(
+                    "INSERT INTO ZREMCDREMINDER "
+                    "(Z_PK, ZTITLE, ZNOTES, ZCOMPLETED, ZFLAGGED, ZPRIORITY, "
+                    "ZISURGENTSTATEENABLEDFORCURRENTUSER, ZDUEDATEDELTAALERTSDATA, "
+                    "ZDUEDATE, ZDISPLAYDATEDATE, ZALLDAY, ZLIST, ZCKIDENTIFIER, "
+                    "ZACCOUNT, ZMARKEDFORDELETION) "
+                    "VALUES (?, ?, NULL, ?, ?, ?, ?, NULL, ?, ?, 0, ?, ?, ?, 0)",
+                    (
+                        rem["Z_PK"],
+                        rem["ZTITLE"],
+                        rem.get("ZCOMPLETED", 0),
+                        rem.get("ZFLAGGED", 0),
+                        rem.get("ZPRIORITY", 0),
+                        rem.get("ZISURGENTSTATEENABLEDFORCURRENTUSER", 0),
+                        rem.get("ZDUEDATE"),
+                        rem.get("ZDUEDATE"),
+                        rem["ZLIST"],
+                        rem.get("ZCKIDENTIFIER", f"CK-{rem['Z_PK']}"),
+                        rem.get("ZACCOUNT", 1),
+                    ),
+                )
+
+        return db
+
+    @contextlib.contextmanager
+    def _multi_account_patch(self, accounts):
+        """Context manager patching discover_accounts and iter_account_dbs.
+
+        accounts: list of (Account_namedtuple, sqlite3.Connection) pairs.
+        """
+        account_list = [acct for acct, _db in accounts]
+        first_db = accounts[0][1] if accounts else None
+
+        @contextlib.contextmanager
+        def _fake_iter_account_dbs(scope):
+            scope_names = {a.name.lower() for a in scope}
+            yield [(acct, db) for acct, db in accounts if acct.name.lower() in scope_names]
+
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=account_list),
+            mock.patch.object(self.remctl, "iter_account_dbs", side_effect=_fake_iter_account_dbs),
+            mock.patch.object(self.remctl, "open_db", return_value=first_db),
+        ):
+            yield
+
+    # ── Group 1: discover_accounts / _store_account_info ─────────────────────
+
+    def test_discover_accounts_excludes_hidden_and_empty_stores(self):
+        """discover_accounts filters out LocalInternal and empty stores."""
+        import pathlib
+
+        fake_paths = [
+            pathlib.Path(f"/tmp/fake-Data-{i}.sqlite") for i in range(3)
+        ]
+
+        info_map = {
+            fake_paths[0]: ("iCloud", "iCloud"),
+            fake_paths[1]: ("Work Exchange", "Exchange"),
+            fake_paths[2]: ("LocalInternal", "Local"),
+        }
+
+        def fake_store_account_info(path):
+            return info_map.get(path)
+
+        def fake_reminder_count(path):
+            return 5  # all non-empty
+
+        # Build a fake STORE_DIR object that returns our paths from glob()
+        class FakeStoreDir:
+            def glob(self, pattern):
+                return list(fake_paths)
+
+        with (
+            mock.patch.object(
+                self.remctl, "reminders_store_access_error", return_value=None
+            ),
+            mock.patch.object(self.remctl, "DB_OVERRIDE", None),
+            mock.patch.object(self.remctl, "STORE_DIR", FakeStoreDir()),
+            mock.patch.object(
+                self.remctl, "_store_account_info", side_effect=fake_store_account_info
+            ),
+            mock.patch.object(
+                self.remctl, "_store_reminder_count", side_effect=fake_reminder_count
+            ),
+            mock.patch.object(
+                self.remctl, "_store_file_group_mtime", return_value=0.0
+            ),
+        ):
+            self.remctl._ACCOUNT_CACHE = None
+            accounts = self.remctl.discover_accounts(force_refresh=True)
+
+        names = [a.name for a in accounts]
+        self.assertIn("iCloud", names)
+        self.assertIn("Work Exchange", names)
+        self.assertNotIn("LocalInternal", names)
+        self.assertEqual(len(accounts), 2)
+
+    def test_store_account_info_reads_name_and_type_from_db(self):
+        """_store_account_info correctly extracts name and type for iCloud and Exchange.
+
+        _store_account_info opens with immutable=1, so the db file must have no
+        WAL/journal.  We create each db directly on disk (not via backup from
+        :memory:) and use PRAGMA journal_mode=DELETE to ensure no WAL exists.
+        """
+        import tempfile, os
+
+        def _make_disk_account_db(path, name, account_type):
+            """Write a minimal account db directly to *path* on disk."""
+            conn = sqlite3.connect(path)
+            conn.execute("PRAGMA journal_mode=DELETE")
+            conn.execute(
+                "CREATE TABLE Z_PRIMARYKEY (Z_NAME TEXT, Z_ENT INTEGER, Z_MAX INTEGER)"
+            )
+            conn.execute(
+                "INSERT INTO Z_PRIMARYKEY (Z_NAME, Z_ENT, Z_MAX) VALUES ('REMCDAccount', 14, 1)"
+            )
+            conn.execute(
+                "CREATE TABLE ZREMCDOBJECT (Z_PK INTEGER, Z_ENT INTEGER, "
+                "ZNAME TEXT, ZMARKEDFORDELETION INTEGER)"
+            )
+            conn.execute(
+                "INSERT INTO ZREMCDOBJECT (Z_PK, Z_ENT, ZNAME, ZMARKEDFORDELETION) "
+                "VALUES (1, 14, ?, 0)",
+                (name,),
+            )
+            conn.execute(
+                "CREATE TABLE ZREMCDREPLICAMANAGER "
+                "(Z_PK INTEGER, Z_ENT INTEGER, ZIDENTIFIER TEXT)"
+            )
+            if account_type == "Exchange":
+                ident = "exchange-uuid/com.apple.exchangesync.exchangesyncd"
+            else:
+                ident = "icloud-uuid/com.apple.reminders"
+            conn.execute(
+                "INSERT INTO ZREMCDREPLICAMANAGER (Z_PK, Z_ENT, ZIDENTIFIER) VALUES (1, 15, ?)",
+                (ident,),
+            )
+            conn.commit()
+            conn.close()
+
+        # iCloud variant
+        fd, icloud_path = tempfile.mkstemp(suffix=".sqlite")
+        os.close(fd)
+        _make_disk_account_db(icloud_path, "iCloud", "iCloud")
+        try:
+            result = self.remctl._store_account_info(icloud_path)
+            self.assertIsNotNone(result)
+            self.assertEqual(result[0], "iCloud")
+            self.assertEqual(result[1], "iCloud")
+        finally:
+            os.unlink(icloud_path)
+
+        # Exchange variant
+        fd, exchange_path = tempfile.mkstemp(suffix=".sqlite")
+        os.close(fd)
+        _make_disk_account_db(exchange_path, "Work Exchange", "Exchange")
+        try:
+            result_ex = self.remctl._store_account_info(exchange_path)
+            self.assertIsNotNone(result_ex)
+            self.assertEqual(result_ex[0], "Work Exchange")
+            self.assertEqual(result_ex[1], "Exchange")
+        finally:
+            os.unlink(exchange_path)
+
+    # ── Group 2: resolve_account_scope ───────────────────────────────────────
+
+    def test_resolve_account_scope_default_returns_first_account(self):
+        """Default scope (no flags, no env) returns only the first account."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        self.remctl._ACCOUNT_CACHE = None
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud, exchange]),
+            mock.patch.object(self.remctl, "load_config", return_value={}),
+            mock.patch.dict(os.environ, {}, clear=False),
+        ):
+            os.environ.pop("REMCTL_ACCOUNT_SCOPE", None)
+            result = self.remctl.resolve_account_scope(
+                SimpleNamespace(account=None, all_accounts=False)
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "iCloud")
+
+    def test_resolve_account_scope_all_accounts_flag(self):
+        """--all-accounts returns all discovered accounts."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud, exchange]),
+            mock.patch.object(self.remctl, "load_config", return_value={}),
+        ):
+            os.environ.pop("REMCTL_ACCOUNT_SCOPE", None)
+            result = self.remctl.resolve_account_scope(
+                SimpleNamespace(account=None, all_accounts=True)
+            )
+        self.assertEqual(len(result), 2)
+        self.assertEqual({a.name for a in result}, {"iCloud", "Exchange"})
+
+    def test_resolve_account_scope_named_account(self):
+        """--account Exchange returns only the Exchange account."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud, exchange]),
+            mock.patch.object(self.remctl, "load_config", return_value={}),
+        ):
+            os.environ.pop("REMCTL_ACCOUNT_SCOPE", None)
+            result = self.remctl.resolve_account_scope(
+                SimpleNamespace(account="Exchange", all_accounts=False)
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "Exchange")
+
+    def test_resolve_account_scope_unknown_account_exits(self):
+        """Unknown --account name triggers sys.exit."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud]),
+            mock.patch.object(self.remctl, "load_config", return_value={}),
+        ):
+            os.environ.pop("REMCTL_ACCOUNT_SCOPE", None)
+            with self.assertRaises(SystemExit):
+                self.remctl.resolve_account_scope(
+                    SimpleNamespace(account="NoSuchAccount", all_accounts=False)
+                )
+
+    def test_resolve_account_scope_env_override(self):
+        """REMCTL_ACCOUNT_SCOPE=all env var returns all accounts."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud, exchange]),
+            mock.patch.object(self.remctl, "load_config", return_value={}),
+            mock.patch.dict(os.environ, {"REMCTL_ACCOUNT_SCOPE": "all"}),
+        ):
+            result = self.remctl.resolve_account_scope(
+                SimpleNamespace(account=None, all_accounts=False)
+            )
+        self.assertEqual(len(result), 2)
+
+    def test_resolve_account_scope_config_override(self):
+        """config.json accountScope=all returns all accounts."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud, exchange]),
+            mock.patch.object(self.remctl, "load_config", return_value={"accountScope": "all"}),
+        ):
+            os.environ.pop("REMCTL_ACCOUNT_SCOPE", None)
+            result = self.remctl.resolve_account_scope(
+                SimpleNamespace(account=None, all_accounts=False)
+            )
+        self.assertEqual(len(result), 2)
+
+    # ── Group 3: READ commands — single-account back-compat ──────────────────
+
+    def test_cmd_lists_single_account_no_account_field_in_json(self):
+        """Single-account cmd_lists JSON output has no 'account' key on any item."""
+        db = self._list_db(["Inbox", "Work"])
+        try:
+            with (
+                mock.patch.object(self.remctl, "open_db", return_value=db),
+                mock.patch.object(self.remctl, "load_config", return_value={}),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_lists(SimpleNamespace(json=True))
+        finally:
+            db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertGreater(len(payload), 0)
+        for item in payload:
+            self.assertNotIn("account", item)
+
+    def _extend_due_window_db_for_serialization(self, db):
+        """Add columns needed by to_dict/serialize_reminder to a _due_window_db instance."""
+        db.execute(
+            "CREATE TABLE IF NOT EXISTS ZREMCDHASHTAGLABEL "
+            "(Z_PK INTEGER PRIMARY KEY, ZNAME TEXT, ZREMINDER3 INTEGER)"
+        )
+        for col in ("ZREMINDER", "ZREMINDER2", "ZREMINDER3", "ZHASHTAGLABEL",
+                    "ZURL", "ZFILENAME", "ZTRIGGER", "ZTIMEINTERVAL",
+                    "ZDATECOMPONENTSDATA", "ZTITLE", "ZLATITUDE", "ZLONGITUDE",
+                    "ZRADIUS", "ZADDRESS", "ZPROXIMITY",
+                    "ZASSIGNEE", "ZORIGINATOR", "ZSTATUS", "ZACCESSLEVEL"):
+            try:
+                db.execute(f"ALTER TABLE ZREMCDOBJECT ADD COLUMN {col}")
+            except Exception:
+                pass  # column may already exist
+
+    def test_cmd_today_single_account_output_unchanged(self):
+        """Single-account cmd_today JSON output has no 'account' key."""
+        from datetime import datetime
+
+        db = self._due_window_db()
+        self._extend_due_window_db_for_serialization(db)
+        now = datetime.now()
+        due_ts = self.remctl.to_ts(now)
+        self._insert_due_reminder(db, 1, "Today Task", due_ts=due_ts, display_ts=due_ts, all_day=False)
+        try:
+            with (
+                mock.patch.object(self.remctl, "open_db", return_value=db),
+                mock.patch.object(self.remctl, "load_config", return_value={}),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_today(SimpleNamespace(json=True, no_overdue=False))
+        finally:
+            db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertGreater(len(payload), 0)
+        for item in payload:
+            self.assertNotIn("account", item)
+
+    def test_cmd_search_single_account_output_unchanged(self):
+        """Single-account cmd_search JSON output has no 'account' key."""
+        db = self._due_window_db()
+        self._extend_due_window_db_for_serialization(db)
+        self._insert_due_reminder(db, 1, "Find me", due_ts=None, display_ts=None, all_day=False)
+        try:
+            with (
+                mock.patch.object(self.remctl, "open_db", return_value=db),
+                mock.patch.object(self.remctl, "load_config", return_value={}),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_search(
+                    SimpleNamespace(json=True, query="Find me", completed=False,
+                                    verbose=False, format=None)
+                )
+        finally:
+            db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertGreater(len(payload), 0)
+        for item in payload:
+            self.assertNotIn("account", item)
+
+    def test_cmd_flagged_single_account_output_unchanged(self):
+        """Single-account cmd_flagged JSON output has no 'account' key."""
+        db = self._due_window_db()
+        self._extend_due_window_db_for_serialization(db)
+        db.execute(
+            "INSERT INTO ZREMCDREMINDER "
+            "(Z_PK, ZTITLE, ZNOTES, ZCOMPLETED, ZFLAGGED, ZPRIORITY, "
+            "ZISURGENTSTATEENABLEDFORCURRENTUSER, ZDUEDATEDELTAALERTSDATA, "
+            "ZDUEDATE, ZDISPLAYDATEDATE, ZALLDAY, ZLIST, ZCKIDENTIFIER, "
+            "ZACCOUNT, ZMARKEDFORDELETION) "
+            "VALUES (1, 'Flagged Task', NULL, 0, 1, 0, 0, NULL, NULL, NULL, 0, 1, 'CK-1', 1, 0)"
+        )
+        try:
+            with (
+                mock.patch.object(self.remctl, "open_db", return_value=db),
+                mock.patch.object(self.remctl, "load_config", return_value={}),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_flagged(
+                    SimpleNamespace(json=True, verbose=False, format=None)
+                )
+        finally:
+            db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertGreater(len(payload), 0)
+        for item in payload:
+            self.assertNotIn("account", item)
+
+    # ── Group 4: READ commands — multi-account (--all-accounts) ──────────────
+
+    def test_cmd_lists_all_accounts_json_includes_account_field(self):
+        """Multi-account cmd_lists JSON includes 'account' and 'accountType' on each item."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db("iCloud", "iCloud", [(1, "Inbox", "CK-1")])
+        exchange_db = self._make_account_db("Exchange", "Exchange", [(2, "Tasks", "CK-2")])
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_lists(
+                    SimpleNamespace(json=True, all_accounts=True, account=None, format=None)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        payload = json.loads(stdout.getvalue())
+        titles = [item["title"] for item in payload]
+        self.assertIn("Inbox", titles)
+        self.assertIn("Tasks", titles)
+        for item in payload:
+            self.assertIn("account", item)
+            self.assertIn("accountType", item)
+
+    def test_cmd_lists_all_accounts_human_shows_account_headers(self):
+        """Multi-account cmd_lists human output shows [iCloud] and [Exchange] headers."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db("iCloud", "iCloud", [(1, "Inbox", "CK-1")])
+        exchange_db = self._make_account_db("Exchange", "Exchange", [(2, "Tasks", "CK-2")])
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_lists(
+                    SimpleNamespace(json=False, all_accounts=True, account=None, format=None)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        output = stdout.getvalue()
+        self.assertIn("iCloud", output)
+        self.assertIn("Exchange", output)
+
+    def test_cmd_today_all_accounts_json_includes_account_field(self):
+        """Multi-account cmd_today JSON includes 'account' on each item."""
+        from datetime import datetime
+
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+
+        now = datetime.now()
+        due_ts = self.remctl.to_ts(now)
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "Inbox", "CK-L1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "iCloud Task", "ZLIST": 1, "ZDUEDATE": due_ts}],
+        )
+        exchange_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Tasks", "CK-L2")],
+            reminders=[{"Z_PK": 2, "ZTITLE": "Exchange Task", "ZLIST": 1, "ZDUEDATE": due_ts}],
+        )
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_today(
+                    SimpleNamespace(json=True, all_accounts=True, account=None,
+                                    no_overdue=False, format=None)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertGreater(len(payload), 0)
+        for item in payload:
+            self.assertIn("account", item)
+        names = {item["account"] for item in payload}
+        self.assertIn("iCloud", names)
+        self.assertIn("Exchange", names)
+
+    def test_cmd_today_all_accounts_human_output_has_full_formatting(self):
+        """Multi-account cmd_today human output contains '[ ]' checkbox format (regression guard for closed-db bug)."""
+        from datetime import datetime
+
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+
+        now = datetime.now()
+        due_ts = self.remctl.to_ts(now)
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "Inbox", "CK-L1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "Task Alpha", "ZLIST": 1, "ZDUEDATE": due_ts}],
+        )
+        exchange_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Tasks", "CK-L2")],
+            reminders=[{"Z_PK": 2, "ZTITLE": "Task Beta", "ZLIST": 1, "ZDUEDATE": due_ts}],
+        )
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_today(
+                    SimpleNamespace(json=False, all_accounts=True, account=None,
+                                    no_overdue=False, format=None)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        output = self.remctl._strip_ansi(stdout.getvalue())
+        # The checkbox format from fmt() must be present — this is the regression guard
+        self.assertIn("[ ]", output)
+        self.assertIn("Task Alpha", output)
+        self.assertIn("Task Beta", output)
+
+    def test_cmd_search_all_accounts_merges_results(self):
+        """Multi-account cmd_search returns results from both accounts with account labels."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "Inbox", "CK-L1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "Meeting notes iCloud", "ZLIST": 1}],
+        )
+        exchange_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Tasks", "CK-L2")],
+            reminders=[{"Z_PK": 2, "ZTITLE": "Meeting notes Exchange", "ZLIST": 1}],
+        )
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_search(
+                    SimpleNamespace(json=True, query="Meeting notes", all_accounts=True,
+                                    account=None, completed=False, verbose=False, format=None)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(len(payload), 2)
+        for item in payload:
+            self.assertIn("account", item)
+
+    def test_cmd_flagged_all_accounts_merges_results(self):
+        """Multi-account cmd_flagged returns flagged reminders from both accounts."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "Inbox", "CK-L1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "iCloud Flagged", "ZLIST": 1, "ZFLAGGED": 1}],
+        )
+        exchange_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Tasks", "CK-L2")],
+            reminders=[{"Z_PK": 2, "ZTITLE": "Exchange Flagged", "ZLIST": 1, "ZFLAGGED": 1}],
+        )
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_flagged(
+                    SimpleNamespace(json=True, all_accounts=True, account=None,
+                                    verbose=False, format=None)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(len(payload), 2)
+        for item in payload:
+            self.assertIn("account", item)
+        titles = {item["title"] for item in payload}
+        self.assertIn("iCloud Flagged", titles)
+        self.assertIn("Exchange Flagged", titles)
+
+    def test_cmd_urgent_all_accounts_merges_results(self):
+        """Multi-account cmd_urgent returns urgent reminders from both accounts."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "Inbox", "CK-L1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "iCloud Urgent",
+                        "ZLIST": 1, "ZISURGENTSTATEENABLEDFORCURRENTUSER": 1}],
+        )
+        exchange_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Tasks", "CK-L2")],
+            reminders=[{"Z_PK": 2, "ZTITLE": "Exchange Urgent",
+                        "ZLIST": 1, "ZISURGENTSTATEENABLEDFORCURRENTUSER": 1}],
+        )
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_urgent(
+                    SimpleNamespace(json=True, all_accounts=True, account=None,
+                                    verbose=False, format=None)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(len(payload), 2)
+        for item in payload:
+            self.assertIn("account", item)
+
+    def test_cmd_overdue_all_accounts_merges_results(self):
+        """Multi-account cmd_overdue returns overdue reminders from both accounts."""
+        from datetime import datetime, timedelta
+
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+
+        yesterday = datetime.now() - timedelta(days=2)
+        past_ts = self.remctl.to_ts(yesterday)
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "Inbox", "CK-L1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "iCloud Overdue", "ZLIST": 1, "ZDUEDATE": past_ts}],
+        )
+        exchange_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Tasks", "CK-L2")],
+            reminders=[{"Z_PK": 2, "ZTITLE": "Exchange Overdue", "ZLIST": 1, "ZDUEDATE": past_ts}],
+        )
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_overdue(
+                    SimpleNamespace(json=True, all_accounts=True, account=None,
+                                    verbose=False, format=None)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(len(payload), 2)
+        for item in payload:
+            self.assertIn("account", item)
+
+    # ── Group 5: READ commands — --account filter ─────────────────────────────
+
+    def test_cmd_lists_account_filter_returns_only_that_account(self):
+        """--account iCloud returns only iCloud lists, not Exchange."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db("iCloud", "iCloud", [(1, "Inbox", "CK-1")])
+        exchange_db = self._make_account_db("Exchange", "Exchange", [(2, "Tasks", "CK-2")])
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_lists(
+                    SimpleNamespace(json=True, all_accounts=False,
+                                    account="iCloud", format=None)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        payload = json.loads(stdout.getvalue())
+        titles = [item["title"] for item in payload]
+        self.assertIn("Inbox", titles)
+        self.assertNotIn("Tasks", titles)
+
+    def test_cmd_show_account_flag_queries_correct_store(self):
+        """--account Exchange for show uses Exchange's list, not iCloud's."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        # Both accounts have list Z_PK=1 but different names
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "iCloud-List", "CK-icloud-1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "iCloud reminder", "ZLIST": 1}],
+        )
+        exchange_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Exchange-List", "CK-exch-1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "Exchange reminder", "ZLIST": 1}],
+        )
+        connected_paths = []
+
+        # Wrap sqlite3.connect in the remctl module so exception types remain intact
+        original_sqlite3_connect = self.remctl.sqlite3.connect
+
+        def fake_connect(path, **kwargs):
+            connected_paths.append(str(path))
+            # Strip the URI parameters and return the correct in-memory db
+            if "fake-exchange" in str(path):
+                exchange_db.row_factory = sqlite3.Row
+                return exchange_db
+            return original_sqlite3_connect(path, **kwargs)
+
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                mock.patch.object(self.remctl.sqlite3, "connect", side_effect=fake_connect),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_show(
+                    SimpleNamespace(
+                        json=True, account="Exchange",
+                        list="Exchange-List", list_id=None,
+                        completed=False, verbose=False, format=None,
+                    )
+                )
+        finally:
+            icloud_db.close()
+            # exchange_db is returned directly; don't double-close via fake_connect
+        output = stdout.getvalue()
+        payload = json.loads(output)
+        titles = [item["title"] for item in payload]
+        self.assertIn("Exchange reminder", titles)
+        self.assertTrue(
+            any("fake-exchange" in p for p in connected_paths),
+            f"Expected Exchange store path in connect calls; got: {connected_paths}",
+        )
+
+    def test_cmd_today_account_filter(self):
+        """--account iCloud for today returns only iCloud's due reminders."""
+        from datetime import datetime
+
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+
+        now = datetime.now()
+        due_ts = self.remctl.to_ts(now)
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "Inbox", "CK-L1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "iCloud Today", "ZLIST": 1, "ZDUEDATE": due_ts}],
+        )
+        exchange_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Tasks", "CK-L2")],
+            reminders=[{"Z_PK": 2, "ZTITLE": "Exchange Today", "ZLIST": 1, "ZDUEDATE": due_ts}],
+        )
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_today(
+                    SimpleNamespace(json=True, all_accounts=False, account="iCloud",
+                                    no_overdue=False, format=None)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        payload = json.loads(stdout.getvalue())
+        titles = [item["title"] for item in payload]
+        self.assertIn("iCloud Today", titles)
+        self.assertNotIn("Exchange Today", titles)
+
+    # ── Group 6: Ambiguity / error cases ─────────────────────────────────────
+
+    def test_resolve_list_ref_across_ambiguous_same_name(self):
+        """Same list name in two accounts returns error='ambiguous' with candidates."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db("iCloud", "iCloud", [(1, "Work", "CK-i1")])
+        exchange_db = self._make_account_db("Exchange", "Exchange", [(2, "Work", "CK-e1")])
+        try:
+            result = self.remctl.resolve_list_ref_across(
+                [(icloud_acct, icloud_db), (exchange_acct, exchange_db)],
+                name="Work",
+                account_name=None,
+            )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get("error"), "ambiguous")
+        candidates = result.get("candidates", [])
+        self.assertEqual(len(candidates), 2)
+        candidate_accounts = {c.get("account") for c in candidates}
+        self.assertIn("iCloud", candidate_accounts)
+        self.assertIn("Exchange", candidate_accounts)
+
+    def test_resolve_list_ref_across_resolved_by_account_name(self):
+        """account_name disambiguates a list that exists in both accounts."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db("iCloud", "iCloud", [(1, "Work", "CK-i1")])
+        exchange_db = self._make_account_db("Exchange", "Exchange", [(2, "Work", "CK-e2")])
+        try:
+            result = self.remctl.resolve_list_ref_across(
+                [(icloud_acct, icloud_db), (exchange_acct, exchange_db)],
+                name="Work",
+                account_name="iCloud",
+            )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        self.assertIsNotNone(result)
+        self.assertNotEqual(result.get("error"), "ambiguous")
+        self.assertEqual(result.get("account"), "iCloud")
+        self.assertEqual(result.get("title"), "Work")
+
+    def test_resolve_reminder_across_ambiguous_same_pk(self):
+        """Same Z_PK in two accounts without account_name causes sys.exit."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "Inbox", "CK-L1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "iCloud rem", "ZLIST": 1}],
+        )
+        exchange_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Tasks", "CK-L2")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "Exchange rem", "ZLIST": 1}],
+        )
+        try:
+            with self.assertRaises(SystemExit):
+                self.remctl.resolve_reminder_across(
+                    [(icloud_acct, icloud_db), (exchange_acct, exchange_db)],
+                    1,
+                    account_name=None,
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+
+    def test_resolve_reminder_across_resolved_by_account(self):
+        """account_name disambiguates when same Z_PK exists in two accounts."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "Inbox", "CK-L1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "iCloud rem", "ZLIST": 1}],
+        )
+        exchange_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Tasks", "CK-L2")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "Exchange rem", "ZLIST": 1}],
+        )
+        try:
+            result = self.remctl.resolve_reminder_across(
+                [(icloud_acct, icloud_db), (exchange_acct, exchange_db)],
+                1,
+                account_name="Exchange",
+            )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        self.assertIsNotNone(result)
+        acct, db, row = result
+        self.assertEqual(acct.name, "Exchange")
+        self.assertEqual(row["ZTITLE"], "Exchange rem")
+
+    # ── Group 6b: sharees / template-info / link cross-account scanning ──────
+
+    def test_cmd_sharees_single_account_json_omits_internal_fields(self):
+        """`sharees --account NAME` (single scope) must not leak _store_path/
+        account/accountType into the JSON 'list' payload — byte-compat with the
+        original single-account output."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        icloud_db = self._make_account_db("iCloud", "iCloud", [(2, "Reminders", "CK-r2")])
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_sharees(
+                    SimpleNamespace(list="Reminders", list_id=None,
+                                    json=True, account="iCloud", all_accounts=False)
+                )
+        finally:
+            icloud_db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["list"]["title"], "Reminders")
+        # internal/multi-only keys must be absent for single-account scope
+        self.assertNotIn("_store_path", payload["list"])
+        self.assertNotIn("account", payload["list"])
+        self.assertNotIn("accountType", payload["list"])
+        self.assertEqual(payload["sharees"], [])
+
+    def test_cmd_sharees_all_accounts_ambiguous_lists_account_qualified(self):
+        """`sharees NAME --all-accounts` on a name present in two accounts errors
+        with account-qualified candidates (cross-account scan)."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db("iCloud", "iCloud", [(1, "Work", "CK-i1")])
+        exchange_db = self._make_account_db("Exchange", "Exchange", [(2, "Work", "CK-e1")])
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stderr(io.StringIO()) as stderr,
+                self.assertRaises(SystemExit),
+            ):
+                self.remctl.cmd_sharees(
+                    SimpleNamespace(list="Work", list_id=None,
+                                    json=False, account=None, all_accounts=True)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        msg = stderr.getvalue()
+        self.assertIn("iCloud", msg)
+        self.assertIn("Exchange", msg)
+        self.assertIn("--account", msg)
+
+    def test_cmd_sharees_account_filter_resolves_in_target_store(self):
+        """`sharees NAME --account X` resolves the list in the named account even
+        when the same name exists elsewhere (no ambiguity error)."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db("iCloud", "iCloud", [(1, "Work", "CK-i1")])
+        exchange_db = self._make_account_db("Exchange", "Exchange", [(2, "Work", "CK-e1")])
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_sharees(
+                    SimpleNamespace(list="Work", list_id=None,
+                                    json=True, account="Exchange", all_accounts=False)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["list"]["title"], "Work")
+        # single-account scope: no leaked label fields
+        self.assertNotIn("_store_path", payload["list"])
+        self.assertNotIn("account", payload["list"])
+
+    def test_cmd_link_all_accounts_scans_for_reminder_id(self):
+        """`link <id> --all-accounts` finds the reminder in whichever store holds
+        it and emits its deep link."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "Inbox", "CK-L1")],
+            reminders=[{"Z_PK": 1, "ZTITLE": "iCloud rem", "ZLIST": 1, "ZCKIDENTIFIER": "ICK-1"}],
+        )
+        exchange_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Tasks", "CK-L2")],
+            reminders=[{"Z_PK": 9, "ZTITLE": "Exchange rem", "ZLIST": 1, "ZCKIDENTIFIER": "ECK-9"}],
+        )
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_link(
+                    SimpleNamespace(ids=[9], list=None, list_id=None,
+                                    completed=False, json=True,
+                                    account=None, all_accounts=True)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]["id"], 9)
+        self.assertEqual(payload[0]["title"], "Exchange rem")
+        self.assertIn("ECK-9", payload[0]["link"])
+        # output is the original 3-field shape — no internal keys
+        self.assertEqual(set(payload[0].keys()), {"id", "title", "link"})
+
+    def test_cmd_template_info_all_accounts_not_found(self):
+        """`template-info NAME --all-accounts` reports not-found cleanly when no
+        store has the template."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db("iCloud", "iCloud", [(1, "Inbox", "CK-L1")])
+        exchange_db = self._make_account_db("Exchange", "Exchange", [(1, "Tasks", "CK-L2")])
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stderr(io.StringIO()) as stderr,
+                self.assertRaises(SystemExit),
+            ):
+                self.remctl.cmd_template_info(
+                    SimpleNamespace(name="Nonexistent", template_id=None,
+                                    json=False, account=None, all_accounts=True)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        self.assertIn("not found", stderr.getvalue())
+
+    def test_cmd_export_refuses_multi_account_scope(self):
+        """export must refuse an 'all-accounts' scope (rc=2) rather than silently
+        exporting only the default account — guards against partial backups."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange_acct = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        icloud_db = self._make_account_db("iCloud", "iCloud", [(1, "Inbox", "CK-1")])
+        exchange_db = self._make_account_db("Exchange", "Exchange", [(2, "Tasks", "CK-2")])
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db), (exchange_acct, exchange_db)]),
+                contextlib.redirect_stderr(io.StringIO()) as stderr,
+                self.assertRaises(SystemExit) as cm,
+            ):
+                self.remctl.cmd_export(
+                    SimpleNamespace(account=None, all_accounts=True,
+                                    list=None, list_id=None, export_format="json", json=False)
+                )
+        finally:
+            icloud_db.close()
+            exchange_db.close()
+        self.assertEqual(cm.exception.code, 2)
+        msg = stderr.getvalue()
+        self.assertIn("single account", msg)
+        self.assertIn("--account", msg)
+
+    def test_cmd_export_single_account_scope_proceeds(self):
+        """export with a single-account scope opens that account and dumps it
+        (no multi-scope error)."""
+        icloud_acct = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        icloud_db = self._make_account_db(
+            "iCloud", "iCloud", [(1, "Inbox", "CK-1")],
+            reminders=[{"Z_PK": 5, "ZTITLE": "Solo", "ZLIST": 1, "ZCKIDENTIFIER": "CK-5"}],
+        )
+        try:
+            with (
+                self._multi_account_patch([(icloud_acct, icloud_db)]),
+                mock.patch.object(self.remctl, "_open_db_for_account", return_value=icloud_db),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_export(
+                    SimpleNamespace(account=None, all_accounts=False,
+                                    list=None, list_id=None, export_format="json", json=False)
+                )
+        finally:
+            icloud_db.close()
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(any(r.get("title") == "Solo" for r in payload))
+
+    # ── Group 7: WRITE commands — _resolve_reminder_for_write ────────────────
+
+    def test_resolve_reminder_for_write_default_uses_open_db(self):
+        """Without --account, _resolve_reminder_for_write calls open_db()."""
+        fake_row = {"ZTITLE": "My Task", "ZCKIDENTIFIER": "ABC", "ZLIST": 1}
+        fake_db = mock.Mock()
+        with (
+            mock.patch.object(self.remctl, "open_db", return_value=fake_db) as open_db_mock,
+            mock.patch.object(self.remctl, "q_reminder", return_value=fake_row),
+        ):
+            db, row = self.remctl._resolve_reminder_for_write(SimpleNamespace(id=1, account=None))
+        open_db_mock.assert_called_once()
+        self.assertIs(db, fake_db)
+        self.assertEqual(row["ZTITLE"], "My Task")
+
+    def test_resolve_reminder_for_write_account_flag_opens_correct_store(self):
+        """--account Exchange opens Exchange's store_path via sqlite3.connect."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        fake_row = {"ZTITLE": "Exchange Task", "ZCKIDENTIFIER": "XYZ", "ZLIST": 1}
+        fake_db = mock.Mock()
+        fake_db.row_factory = None
+        connected_paths = []
+
+        def fake_connect(path, **kwargs):
+            connected_paths.append(path)
+            return fake_db
+
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud, exchange]),
+            mock.patch.object(sqlite3, "connect", side_effect=fake_connect),
+            mock.patch.object(self.remctl, "q_reminder", return_value=fake_row),
+        ):
+            db, row = self.remctl._resolve_reminder_for_write(
+                SimpleNamespace(id=1, account="Exchange")
+            )
+        # The connect path should contain the Exchange store path
+        self.assertTrue(
+            any("fake-exchange.sqlite" in str(p) for p in connected_paths),
+            f"Expected Exchange store path in connect calls; got: {connected_paths}",
+        )
+        self.assertEqual(row["ZTITLE"], "Exchange Task")
+
+    def test_resolve_reminder_for_write_not_found_exits(self):
+        """Reminder not found triggers sys.exit."""
+        fake_db = mock.Mock()
+        with (
+            mock.patch.object(self.remctl, "open_db", return_value=fake_db),
+            mock.patch.object(self.remctl, "q_reminder", return_value=None),
+            self.assertRaises(SystemExit),
+        ):
+            self.remctl._resolve_reminder_for_write(SimpleNamespace(id=99, account=None))
+
+    def test_resolve_reminder_for_write_unknown_account_exits(self):
+        """Unknown --account name triggers sys.exit with useful message."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud]),
+        ):
+            with self.assertRaises(SystemExit):
+                self.remctl._resolve_reminder_for_write(
+                    SimpleNamespace(id=1, account="NoSuchAccount")
+                )
+
+    # ── Group 8: WRITE commands — done/undone/delete/flag/unflag with --account ──
+
+    def _make_write_reminder(self, title="Task", ckid="CK-WRITE-001"):
+        return {
+            "ZCKIDENTIFIER": ckid,
+            "ZTITLE": title,
+            "list_name": "Inbox",
+            "ZLIST": 1,
+            "ZDUEDATE": None,
+        }
+
+    def test_cmd_done_with_account_flag_looks_up_correct_store(self):
+        """cmd_done with --account Exchange calls bridge_call with reminder's ZCKIDENTIFIER."""
+        fake_row = self._make_write_reminder("Exchange Done Task", "EXCH-DONE-001")
+        fake_db = mock.Mock()
+        with (
+            mock.patch.object(
+                self.remctl, "_resolve_reminder_for_write", return_value=(fake_db, fake_row)
+            ),
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(
+                self.remctl, "bridge_call",
+                return_value={"status": "completed", "id": fake_row["ZCKIDENTIFIER"]},
+            ) as bridge_call,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_done(SimpleNamespace(id=1, json=True, account="Exchange"))
+        bridge_call.assert_called_once()
+        payload = bridge_call.call_args.args[0]
+        self.assertEqual(payload["id"], "EXCH-DONE-001")
+        self.assertEqual(payload["action"], "complete")
+
+    def test_cmd_undone_with_account_flag(self):
+        """cmd_undone with --account Exchange calls bridge_call with the correct identifier."""
+        fake_row = self._make_write_reminder("Exchange Undone Task", "EXCH-UNDONE-001")
+        fake_db = mock.Mock()
+        with (
+            mock.patch.object(
+                self.remctl, "_resolve_reminder_for_write", return_value=(fake_db, fake_row)
+            ),
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(
+                self.remctl, "bridge_call",
+                return_value={"status": "uncompleted", "id": fake_row["ZCKIDENTIFIER"]},
+            ) as bridge_call,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_undone(SimpleNamespace(id=1, json=True, account="Exchange"))
+        bridge_call.assert_called_once()
+        payload = bridge_call.call_args.args[0]
+        self.assertEqual(payload["id"], "EXCH-UNDONE-001")
+        self.assertEqual(payload["action"], "uncomplete")
+
+    def test_cmd_delete_with_account_flag(self):
+        """cmd_delete with --account Exchange and force=True calls bridge_call delete."""
+        fake_row = self._make_write_reminder("Exchange Delete Task", "EXCH-DEL-001")
+        fake_db = mock.Mock()
+        with (
+            mock.patch.object(
+                self.remctl, "_resolve_reminder_for_write", return_value=(fake_db, fake_row)
+            ),
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(
+                self.remctl, "bridge_call",
+                return_value={"status": "deleted", "id": fake_row["ZCKIDENTIFIER"]},
+            ) as bridge_call,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_delete(
+                SimpleNamespace(id=1, json=True, account="Exchange", force=True)
+            )
+        bridge_call.assert_called_once()
+        payload = bridge_call.call_args.args[0]
+        self.assertEqual(payload["id"], "EXCH-DEL-001")
+        self.assertEqual(payload["action"], "delete")
+
+    def test_cmd_flag_with_account_flag(self):
+        """cmd_flag with --account Exchange uses AppleScript (flagged-first path)."""
+        fake_row = self._make_write_reminder("Exchange Flag Task", "EXCH-FLAG-001")
+        fake_db = mock.Mock()
+        with (
+            mock.patch.object(
+                self.remctl, "_resolve_reminder_for_write", return_value=(fake_db, fake_row)
+            ),
+            mock.patch.object(
+                self.remctl, "osa_by_id_try", return_value=True
+            ) as osa_mock,
+            mock.patch.object(self.remctl, "bridge_available", return_value=False),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_flag(SimpleNamespace(id=1, json=True, account="Exchange"))
+        osa_mock.assert_called_once()
+        script = osa_mock.call_args.args[2]
+        self.assertIn("set flagged of r to true", script)
+
+    def test_cmd_unflag_with_account_flag(self):
+        """cmd_unflag with --account Exchange uses AppleScript (unflag-first path)."""
+        fake_row = self._make_write_reminder("Exchange Unflag Task", "EXCH-UNFLAG-001")
+        fake_db = mock.Mock()
+        with (
+            mock.patch.object(
+                self.remctl, "_resolve_reminder_for_write", return_value=(fake_db, fake_row)
+            ),
+            mock.patch.object(
+                self.remctl, "osa_by_id_try", return_value=True
+            ) as osa_mock,
+            mock.patch.object(self.remctl, "bridge_available", return_value=False),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_unflag(SimpleNamespace(id=1, json=True, account="Exchange"))
+        osa_mock.assert_called_once()
+        script = osa_mock.call_args.args[2]
+        self.assertIn("set flagged of r to false", script)
+
+    # ── Group 9: WRITE — cmd_add with --account ───────────────────────────────
+
+    def test_cmd_add_with_account_opens_correct_store_for_list_lookup(self):
+        """cmd_add with account=["Exchange"] connects to Exchange's store_path for list lookup."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        connected_paths = []
+
+        def fake_connect(path, **kwargs):
+            connected_paths.append(str(path))
+            fake_db = mock.Mock()
+            fake_db.row_factory = None
+            return fake_db
+
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud, exchange]),
+            mock.patch.object(sqlite3, "connect", side_effect=fake_connect),
+            mock.patch.object(
+                self.remctl, "resolve_list_or_die",
+                return_value={"id": 1, "title": "Tasks", "requested": "Tasks", "method": "exact"},
+            ),
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(
+                self.remctl, "bridge_call",
+                return_value={"status": "created", "id": "NEW-001"},
+            ),
+            mock.patch.object(self.remctl, "q_reminder_by_identifier", return_value=None),
+            mock.patch.object(self.remctl, "private_metadata_enabled", return_value=False),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_add(
+                SimpleNamespace(
+                    title="New Task",
+                    list="Tasks",
+                    list_id=None,
+                    notes=None,
+                    due=None,
+                    priority=None,
+                    flag=False,
+                    tags=None,
+                    url=None,
+                    recurrence=None,
+                    alarm=None,
+                    private=False,
+                    private_metadata=False,
+                    section=None,
+                    new_section=None,
+                    subtask=None,
+                    image=None,
+                    json=True,
+                    account=["Exchange"],
+                )
+            )
+        self.assertTrue(
+            any("fake-exchange.sqlite" in p for p in connected_paths),
+            f"Expected Exchange store path in connect calls; got: {connected_paths}",
+        )
+
+    def test_cmd_add_without_account_uses_open_db(self):
+        """cmd_add without --account calls open_db() for list lookup."""
+        fake_db = mock.Mock()
+        fake_db.row_factory = None
+        with (
+            mock.patch.object(self.remctl, "open_db", return_value=fake_db) as open_db_mock,
+            mock.patch.object(
+                self.remctl, "resolve_list_or_die",
+                return_value={"id": 1, "title": "Inbox", "requested": "Inbox", "method": "exact"},
+            ),
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(
+                self.remctl, "bridge_call",
+                return_value={"status": "created", "id": "NEW-002"},
+            ),
+            mock.patch.object(self.remctl, "q_reminder_by_identifier", return_value=None),
+            mock.patch.object(self.remctl, "private_metadata_enabled", return_value=False),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_add(
+                SimpleNamespace(
+                    title="No Account Task",
+                    list="Inbox",
+                    list_id=None,
+                    notes=None,
+                    due=None,
+                    priority=None,
+                    flag=False,
+                    tags=None,
+                    url=None,
+                    recurrence=None,
+                    alarm=None,
+                    private=False,
+                    private_metadata=False,
+                    section=None,
+                    new_section=None,
+                    subtask=None,
+                    image=None,
+                    json=True,
+                    account=None,
+                )
+            )
+        open_db_mock.assert_called()
+
+    # ── Group 10: config / accounts command ──────────────────────────────────
+
+    def test_cmd_accounts_json_lists_all_discovered_accounts(self):
+        """cmd_accounts --json lists all discovered accounts with name, type, storePath."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        with (
+            mock.patch.object(
+                self.remctl, "discover_accounts", return_value=[icloud, exchange]
+            ),
+            contextlib.redirect_stdout(io.StringIO()) as stdout,
+        ):
+            self.remctl.cmd_accounts(SimpleNamespace(json=True))
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(len(payload), 2)
+        names = {item["name"] for item in payload}
+        self.assertIn("iCloud", names)
+        self.assertIn("Exchange", names)
+        for item in payload:
+            self.assertIn("name", item)
+            self.assertIn("type", item)
+            self.assertIn("storePath", item)
+
+    def test_cmd_accounts_human_shows_default_label(self):
+        """cmd_accounts human output marks the first account as (default)."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        with (
+            mock.patch.object(
+                self.remctl, "discover_accounts", return_value=[icloud, exchange]
+            ),
+            contextlib.redirect_stdout(io.StringIO()) as stdout,
+        ):
+            self.remctl.cmd_accounts(SimpleNamespace(json=False))
+        output = self.remctl._strip_ansi(stdout.getvalue())
+        self.assertIn("(default)", output)
+        # The first account (iCloud) should be the default
+        lines = output.splitlines()
+        default_line = next((l for l in lines if "(default)" in l), "")
+        self.assertIn("iCloud", default_line)
+
+    def test_cmd_config_set_and_get(self):
+        """cmd_config set accountScope all; then get returns 'all'."""
+        config_store = {}
+
+        def fake_load_config():
+            return dict(config_store)
+
+        def fake_save_config(data):
+            config_store.clear()
+            config_store.update(data)
+
+        with (
+            mock.patch.object(self.remctl, "load_config", side_effect=fake_load_config),
+            mock.patch.object(self.remctl, "save_config", side_effect=fake_save_config),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_config(
+                SimpleNamespace(key="accountScope", value="all", json=False)
+            )
+
+        self.assertEqual(config_store.get("accountScope"), "all")
+
+        with (
+            mock.patch.object(self.remctl, "load_config", side_effect=fake_load_config),
+            mock.patch.object(self.remctl, "save_config", side_effect=fake_save_config),
+            contextlib.redirect_stdout(io.StringIO()) as stdout,
+        ):
+            self.remctl.cmd_config(
+                SimpleNamespace(key="accountScope", value=None, json=False)
+            )
+        self.assertIn("all", stdout.getvalue())
+
+    def test_is_multi_account_mode_false_by_default(self):
+        """Default args with no flags, no env, no config returns False."""
+        with (
+            mock.patch.object(self.remctl, "load_config", return_value={}),
+            mock.patch.dict(os.environ, {}, clear=False),
+        ):
+            os.environ.pop("REMCTL_ACCOUNT_SCOPE", None)
+            result = self.remctl._is_multi_account_mode(
+                SimpleNamespace(all_accounts=False, account=None)
+            )
+        self.assertFalse(result)
+
+    def test_is_multi_account_mode_true_with_all_accounts_flag(self):
+        """all_accounts=True returns True from _is_multi_account_mode."""
+        with mock.patch.object(self.remctl, "load_config", return_value={}):
+            os.environ.pop("REMCTL_ACCOUNT_SCOPE", None)
+            result = self.remctl._is_multi_account_mode(
+                SimpleNamespace(all_accounts=True, account=None)
+            )
+        self.assertTrue(result)
+
+    def test_is_multi_account_mode_true_with_account_flag(self):
+        """account='iCloud' returns True from _is_multi_account_mode."""
+        with mock.patch.object(self.remctl, "load_config", return_value={}):
+            os.environ.pop("REMCTL_ACCOUNT_SCOPE", None)
+            result = self.remctl._is_multi_account_mode(
+                SimpleNamespace(all_accounts=False, account="iCloud")
+            )
+        self.assertTrue(result)
+
+    def test_is_multi_account_mode_true_with_env(self):
+        """REMCTL_ACCOUNT_SCOPE=all env var returns True from _is_multi_account_mode."""
+        with (
+            mock.patch.object(self.remctl, "load_config", return_value={}),
+            mock.patch.dict(os.environ, {"REMCTL_ACCOUNT_SCOPE": "all"}),
+        ):
+            result = self.remctl._is_multi_account_mode(
+                SimpleNamespace(all_accounts=False, account=None)
+            )
+        self.assertTrue(result)
+
+    def test_is_multi_account_mode_true_with_config_scope(self):
+        """accountScope in config makes _is_multi_account_mode True."""
+        with mock.patch.object(self.remctl, "load_config", return_value={"accountScope": "all"}):
+            result = self.remctl._is_multi_account_mode(
+                SimpleNamespace(all_accounts=False, account=None)
+            )
+        self.assertTrue(result)
+
+    # ── Group 11: _open_db_for_account ───────────────────────────────────────
+
+    def test_open_db_for_account_none_uses_open_db(self):
+        """_open_db_for_account(None) falls back to open_db()."""
+        sentinel = mock.Mock()
+        with mock.patch.object(self.remctl, "open_db", return_value=sentinel) as open_db_mock:
+            result = self.remctl._open_db_for_account(None)
+        open_db_mock.assert_called_once()
+        self.assertIs(result, sentinel)
+
+    def test_open_db_for_account_named_opens_correct_store(self):
+        """_open_db_for_account('Exchange') connects to Exchange's store_path."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        connected = []
+
+        def fake_connect(conn_str, *args, **kwargs):
+            connected.append(str(conn_str))
+            return mock.Mock()
+
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud, exchange]),
+            mock.patch.object(sqlite3, "connect", side_effect=fake_connect),
+        ):
+            self.remctl._open_db_for_account("Exchange")
+        self.assertTrue(any("fake-exchange.sqlite" in p for p in connected),
+                        f"got: {connected}")
+
+    def test_open_db_for_account_case_insensitive(self):
+        """Account name matching is case-insensitive."""
+        exchange = self.remctl.Account("/tmp/fake-exchange.sqlite", "Exchange", "Exchange")
+        connected = []
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[exchange]),
+            mock.patch.object(sqlite3, "connect", side_effect=lambda conn_str, *a, **k: connected.append(str(conn_str)) or mock.Mock()),
+        ):
+            self.remctl._open_db_for_account("EXCHANGE")
+        self.assertTrue(any("fake-exchange.sqlite" in p for p in connected))
+
+    def test_open_db_for_account_unknown_exits(self):
+        """Unknown account name exits with an error."""
+        icloud = self.remctl.Account("/tmp/fake-icloud.sqlite", "iCloud", "iCloud")
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud]),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit),
+        ):
+            self.remctl._open_db_for_account("NoSuchAccount")
+        self.assertIn("NoSuchAccount", stderr.getvalue())
+
+    # ── Group 12: _ek_identifier (Exchange identifier resolution) ────────────
+
+    def test_ek_identifier_returns_ckidentifier_for_icloud(self):
+        """When ZCKIDENTIFIER is present it is returned directly, no bridge call."""
+        r = {"ZCKIDENTIFIER": "CK-ABC", "list_name": "Reminders", "ZTITLE": "Task"}
+        with mock.patch.object(self.remctl, "bridge_call") as bridge_call:
+            result = self.remctl._ek_identifier(r)
+        self.assertEqual(result, "CK-ABC")
+        bridge_call.assert_not_called()
+
+    def test_ek_identifier_falls_back_to_find_reminder_for_exchange(self):
+        """Exchange reminder (no ZCKIDENTIFIER) resolves via list_calendars + find_reminder."""
+        r = {"ZCKIDENTIFIER": None, "list_name": "Tasks", "ZTITLE": "Exch Task"}
+
+        def fake_bridge_call(data):
+            if data["action"] == "list_calendars":
+                return [{"title": "Tasks", "calendarIdentifier": "CAL-EX",
+                         "sourceTitle": "Exchange", "sourceType": "Exchange"}]
+            if data["action"] == "find_reminder":
+                self.assertEqual(data["calendarIdentifier"], "CAL-EX")
+                self.assertEqual(data["title"], "Exch Task")
+                return {"calendarItemIdentifier": "EK-ITEM-99"}
+            return None
+
+        with (
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(self.remctl, "bridge_call", side_effect=fake_bridge_call),
+        ):
+            result = self.remctl._ek_identifier(r, account_name="Exchange")
+        self.assertEqual(result, "EK-ITEM-99")
+
+    def test_ek_identifier_narrows_by_account_when_list_name_collides(self):
+        """When the same list name exists in two accounts, the account hint selects the right calendar."""
+        r = {"ZCKIDENTIFIER": None, "list_name": "Tasks", "ZTITLE": "T"}
+
+        def fake_bridge_call(data):
+            if data["action"] == "list_calendars":
+                return [
+                    {"title": "Tasks", "calendarIdentifier": "CAL-A", "sourceTitle": "AcctA"},
+                    {"title": "Tasks", "calendarIdentifier": "CAL-B", "sourceTitle": "AcctB"},
+                ]
+            if data["action"] == "find_reminder":
+                self.assertEqual(data["calendarIdentifier"], "CAL-B")
+                return {"calendarItemIdentifier": "EK-B"}
+            return None
+
+        with (
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(self.remctl, "bridge_call", side_effect=fake_bridge_call),
+        ):
+            result = self.remctl._ek_identifier(r, account_name="AcctB")
+        self.assertEqual(result, "EK-B")
+
+    def test_ek_identifier_none_when_bridge_unavailable(self):
+        """No ZCKIDENTIFIER and no bridge → None."""
+        r = {"ZCKIDENTIFIER": None, "list_name": "Tasks", "ZTITLE": "T"}
+        with mock.patch.object(self.remctl, "bridge_available", return_value=False):
+            self.assertIsNone(self.remctl._ek_identifier(r))
+
+    def test_ek_identifier_none_when_no_list_or_title(self):
+        """No ZCKIDENTIFIER and missing list_name/title → None."""
+        r = {"ZCKIDENTIFIER": None, "list_name": None, "ZTITLE": None}
+        with (
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(self.remctl, "bridge_call") as bridge_call,
+        ):
+            self.assertIsNone(self.remctl._ek_identifier(r))
+        bridge_call.assert_not_called()
+
+    # ── Group 13: _resolve_reminder_for_write cross-account scan ─────────────
+
+    def _connect_by_path(self, mapping):
+        """Return a sqlite3.connect replacement mapping store paths to in-memory dbs."""
+        def fake_connect(conn_str, *args, **kwargs):
+            for path, db in mapping.items():
+                if path in str(conn_str):
+                    return db
+            raise sqlite3.OperationalError(f"unmapped uri: {conn_str}")
+        return fake_connect
+
+    def test_resolve_reminder_for_write_multi_scope_unique_match(self):
+        """Multi-account scope: a unique id match resolves and stamps a.account."""
+        icloud = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        ic_db = self._make_account_db("iCloud", "iCloud", [(1, "Reminders", "CK-1")],
+                                      reminders=[{"Z_PK": 50, "ZTITLE": "iC", "ZLIST": 1}])
+        ex_db = self._make_account_db("Exchange", "Exchange", [(1, "Tasks", "CK-2")],
+                                      reminders=[{"Z_PK": 99, "ZTITLE": "ExOnly", "ZLIST": 1}])
+        a = SimpleNamespace(id=99, account=None)
+        try:
+            with (
+                mock.patch.object(self.remctl, "_is_multi_account_mode", return_value=True),
+                mock.patch.object(self.remctl, "resolve_account_scope", return_value=[icloud, exchange]),
+                mock.patch.object(sqlite3, "connect",
+                                  side_effect=self._connect_by_path({"/tmp/ic.sqlite": ic_db,
+                                                                     "/tmp/ex.sqlite": ex_db})),
+            ):
+                db, row = self.remctl._resolve_reminder_for_write(a)
+            self.assertEqual(row["ZTITLE"], "ExOnly")
+            self.assertEqual(a.account, "Exchange")  # stamped for downstream write path
+        finally:
+            ic_db.close()
+            ex_db.close()
+
+    def test_resolve_reminder_for_write_multi_scope_ambiguous_exits(self):
+        """Same id in two active accounts raises an ambiguity error."""
+        a1 = self.remctl.Account("/tmp/a1.sqlite", "AcctA", "Exchange")
+        a2 = self.remctl.Account("/tmp/a2.sqlite", "AcctB", "Exchange")
+        db1 = self._make_account_db("AcctA", "Exchange", [(1, "Tasks", "CK-1")],
+                                    reminders=[{"Z_PK": 5, "ZTITLE": "A5", "ZLIST": 1}])
+        db2 = self._make_account_db("AcctB", "Exchange", [(1, "Tasks", "CK-2")],
+                                    reminders=[{"Z_PK": 5, "ZTITLE": "B5", "ZLIST": 1}])
+        try:
+            with (
+                mock.patch.object(self.remctl, "_is_multi_account_mode", return_value=True),
+                mock.patch.object(self.remctl, "resolve_account_scope", return_value=[a1, a2]),
+                mock.patch.object(sqlite3, "connect",
+                                  side_effect=self._connect_by_path({"/tmp/a1.sqlite": db1,
+                                                                     "/tmp/a2.sqlite": db2})),
+                contextlib.redirect_stderr(io.StringIO()) as stderr,
+                self.assertRaises(SystemExit),
+            ):
+                self.remctl._resolve_reminder_for_write(SimpleNamespace(id=5, account=None))
+            err = stderr.getvalue()
+            self.assertIn("multiple accounts", err)
+            self.assertIn("AcctA", err)
+            self.assertIn("AcctB", err)
+        finally:
+            db1.close()
+            db2.close()
+
+    def test_resolve_reminder_for_write_multi_scope_not_found_exits(self):
+        """An id absent from every active account exits cleanly."""
+        a1 = self.remctl.Account("/tmp/a1.sqlite", "AcctA", "Exchange")
+        db1 = self._make_account_db("AcctA", "Exchange", [(1, "Tasks", "CK-1")],
+                                    reminders=[{"Z_PK": 1, "ZTITLE": "A1", "ZLIST": 1}])
+        try:
+            with (
+                mock.patch.object(self.remctl, "_is_multi_account_mode", return_value=True),
+                mock.patch.object(self.remctl, "resolve_account_scope", return_value=[a1]),
+                mock.patch.object(sqlite3, "connect",
+                                  side_effect=self._connect_by_path({"/tmp/a1.sqlite": db1})),
+                contextlib.redirect_stderr(io.StringIO()),
+                self.assertRaises(SystemExit),
+            ):
+                self.remctl._resolve_reminder_for_write(SimpleNamespace(id=777, account=None))
+        finally:
+            db1.close()
+
+    # ── Group 14: _gather_stats / cmd_stats (incl. overdue-definition fix) ───
+
+    def _stats_db(self):
+        """A single-account db with a controlled mix for stats assertions."""
+        from datetime import timedelta
+        db = self._make_account_db("iCloud", "iCloud", [(1, "Reminders", "CK-L1")])
+        sod = self.remctl.start_of_day()
+        yesterday = self.remctl.to_ts(sod - timedelta(days=1))
+        today_midnight = self.remctl.to_ts(sod)
+        tomorrow = self.remctl.to_ts(sod + timedelta(days=1))
+        # overdue: due yesterday, timed
+        db.execute("INSERT INTO ZREMCDREMINDER (Z_PK, ZTITLE, ZCOMPLETED, ZFLAGGED, ZPRIORITY, "
+                   "ZISURGENTSTATEENABLEDFORCURRENTUSER, ZDUEDATE, ZDISPLAYDATEDATE, ZALLDAY, ZLIST, "
+                   "ZCKIDENTIFIER, ZACCOUNT, ZMARKEDFORDELETION) "
+                   "VALUES (1,'Overdue',0,0,0,0,?,?,0,1,'CK-1',1,0)", (yesterday, yesterday))
+        # all-day due today → NOT overdue (display date == start of day)
+        db.execute("INSERT INTO ZREMCDREMINDER (Z_PK, ZTITLE, ZCOMPLETED, ZFLAGGED, ZPRIORITY, "
+                   "ZISURGENTSTATEENABLEDFORCURRENTUSER, ZDUEDATE, ZDISPLAYDATEDATE, ZALLDAY, ZLIST, "
+                   "ZCKIDENTIFIER, ZACCOUNT, ZMARKEDFORDELETION) "
+                   "VALUES (2,'AllDayToday',0,0,0,0,?,?,1,1,'CK-2',1,0)", (today_midnight, today_midnight))
+        # flagged + future
+        db.execute("INSERT INTO ZREMCDREMINDER (Z_PK, ZTITLE, ZCOMPLETED, ZFLAGGED, ZPRIORITY, "
+                   "ZISURGENTSTATEENABLEDFORCURRENTUSER, ZDUEDATE, ZDISPLAYDATEDATE, ZALLDAY, ZLIST, "
+                   "ZCKIDENTIFIER, ZACCOUNT, ZMARKEDFORDELETION) "
+                   "VALUES (3,'Flagged',0,1,0,0,?,?,0,1,'CK-3',1,0)", (tomorrow, tomorrow))
+        # completed
+        db.execute("INSERT INTO ZREMCDREMINDER (Z_PK, ZTITLE, ZCOMPLETED, ZFLAGGED, ZPRIORITY, "
+                   "ZISURGENTSTATEENABLEDFORCURRENTUSER, ZDUEDATE, ZDISPLAYDATEDATE, ZALLDAY, ZLIST, "
+                   "ZCKIDENTIFIER, ZACCOUNT, ZMARKEDFORDELETION) "
+                   "VALUES (4,'Done',1,0,0,0,NULL,NULL,0,1,'CK-4',1,0)")
+        return db
+
+    def test_gather_stats_counts(self):
+        """_gather_stats returns correct totals/active/completed/flagged."""
+        db = self._stats_db()
+        try:
+            with mock.patch.object(self.remctl, "_REMINDER_COLUMN_CACHE", {}):
+                s = self.remctl._gather_stats(db)
+        finally:
+            db.close()
+        self.assertEqual(s["total"], 4)
+        self.assertEqual(s["active"], 3)
+        self.assertEqual(s["completed"], 1)
+        self.assertEqual(s["flagged"], 1)
+
+    def test_gather_stats_overdue_matches_q_overdue(self):
+        """stats overdue count equals what q_overdue lists (canonical definition)."""
+        db = self._stats_db()
+        try:
+            with mock.patch.object(self.remctl, "_REMINDER_COLUMN_CACHE", {}):
+                s = self.remctl._gather_stats(db)
+                overdue_rows = self.remctl.q_overdue(db)
+        finally:
+            db.close()
+        # Only the due-yesterday reminder is overdue; all-day-today is NOT.
+        self.assertEqual(s["overdue"], 1)
+        self.assertEqual(s["overdue"], len(overdue_rows))
+
+    def test_gather_stats_all_day_today_not_overdue(self):
+        """An all-day reminder due today must not be counted overdue."""
+        db = self._stats_db()
+        try:
+            with mock.patch.object(self.remctl, "_REMINDER_COLUMN_CACHE", {}):
+                overdue_rows = self.remctl.q_overdue(db)
+        finally:
+            db.close()
+        titles = {r["ZTITLE"] for r in overdue_rows}
+        self.assertNotIn("AllDayToday", titles)
+        self.assertIn("Overdue", titles)
+
+    def test_cmd_stats_multi_account_totals(self):
+        """cmd_stats --all-accounts JSON has per-account stats and a summed total."""
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ex = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        ic_db = self._make_account_db("iCloud", "iCloud", [(1, "Reminders", "CK-1")],
+                                      reminders=[{"Z_PK": 1, "ZTITLE": "A", "ZLIST": 1}])
+        ex_db = self._make_account_db("Exchange", "Exchange", [(1, "Tasks", "CK-2")],
+                                      reminders=[{"Z_PK": 1, "ZTITLE": "B", "ZLIST": 1},
+                                                 {"Z_PK": 2, "ZTITLE": "C", "ZLIST": 1}])
+        try:
+            with (
+                self._multi_account_patch([(ic, ic_db), (ex, ex_db)]),
+                mock.patch.object(self.remctl, "_REMINDER_COLUMN_CACHE", {}),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_stats(SimpleNamespace(json=True, all_accounts=True, account=None))
+            payload = json.loads(stdout.getvalue())
+        finally:
+            ic_db.close()
+            ex_db.close()
+        self.assertEqual(payload["total"]["total"], 3)
+        self.assertIn("iCloud", payload["accounts"])
+        self.assertIn("Exchange", payload["accounts"])
+        self.assertEqual(payload["accounts"]["Exchange"]["total"], 2)
+
+    # ── Group 15: multi-account tags (merge + dedup) ─────────────────────────
+
+    def test_cmd_tags_all_accounts_merges_and_dedups(self):
+        """Tags from all accounts are merged, deduplicated, and sorted."""
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ex = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        ic_db = self._make_account_db("iCloud", "iCloud", [(1, "R", "CK-1")])
+        ex_db = self._make_account_db("Exchange", "Exchange", [(1, "T", "CK-2")])
+        ic_db.execute("INSERT INTO ZREMCDHASHTAGLABEL (Z_PK, ZNAME) VALUES (1,'work'),(2,'home')")
+        ex_db.execute("INSERT INTO ZREMCDHASHTAGLABEL (Z_PK, ZNAME) VALUES (1,'work'),(2,'urgent')")
+        try:
+            with (
+                self._multi_account_patch([(ic, ic_db), (ex, ex_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_tags(SimpleNamespace(json=True, all_accounts=True, account=None))
+            payload = json.loads(stdout.getvalue())
+        finally:
+            ic_db.close()
+            ex_db.close()
+        names = [t["name"] for t in payload]
+        self.assertEqual(names, ["home", "urgent", "work"])  # deduped + sorted
+
+    # ── Group 16: multi-account sections (label consistency) ─────────────────
+
+    def _sections_account_db(self, account_name, account_type, list_name, sections):
+        db = self._make_account_db(account_name, account_type, [(1, list_name, "CK-L1")])
+        for i, sec in enumerate(sections, start=1):
+            db.execute("INSERT INTO ZREMCDBASESECTION (Z_PK, ZDISPLAYNAME, ZLIST, ZCKIDENTIFIER, ZMARKEDFORDELETION) "
+                       "VALUES (?,?,1,?,0)", (i, sec, f"SEC-{i}"))
+        return db
+
+    def test_cmd_sections_single_account_no_label(self):
+        """sections --account X shows no redundant account label (single scope)."""
+        ex = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        ex_db = self._sections_account_db("Exchange", "Exchange", "Tasks", ["Phase 1"])
+        try:
+            with (
+                self._multi_account_patch([(ex, ex_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_sections(SimpleNamespace(json=False, all_accounts=False, account="Exchange"))
+            out = self.remctl._strip_ansi(stdout.getvalue())
+        finally:
+            ex_db.close()
+        self.assertIn("Tasks:", out)
+        self.assertNotIn("(Exchange)", out)
+
+    def test_cmd_sections_multi_account_shows_label(self):
+        """sections --all-accounts labels each list with its account."""
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ex = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        ic_db = self._sections_account_db("iCloud", "iCloud", "Groceries", ["Produce"])
+        ex_db = self._sections_account_db("Exchange", "Exchange", "Tasks", ["Phase 1"])
+        try:
+            with (
+                self._multi_account_patch([(ic, ic_db), (ex, ex_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_sections(SimpleNamespace(json=False, all_accounts=True, account=None))
+            out = self.remctl._strip_ansi(stdout.getvalue())
+        finally:
+            ic_db.close()
+            ex_db.close()
+        self.assertIn("(iCloud)", out)
+        self.assertIn("(Exchange)", out)
+
+    # ── Group 17: config storeDir / dbPath + _apply_config_path_overrides ────
+
+    def test_cmd_config_set_and_clear_store_dir(self):
+        store = {}
+        with (
+            mock.patch.object(self.remctl, "load_config", side_effect=lambda: dict(store)),
+            mock.patch.object(self.remctl, "save_config", side_effect=lambda d: (store.clear(), store.update(d))),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_config(SimpleNamespace(key="storeDir", value="/tmp/x", json=False))
+            self.assertEqual(store.get("storeDir"), "/tmp/x")
+            # clearing with empty string removes the key
+            self.remctl.cmd_config(SimpleNamespace(key="storeDir", value="", json=False))
+            self.assertNotIn("storeDir", store)
+
+    def test_cmd_config_unknown_key_warns(self):
+        store = {}
+        with (
+            mock.patch.object(self.remctl, "load_config", side_effect=lambda: dict(store)),
+            mock.patch.object(self.remctl, "save_config", side_effect=lambda d: (store.clear(), store.update(d))),
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+        ):
+            self.remctl.cmd_config(SimpleNamespace(key="bogusKey", value="x", json=False))
+        self.assertIn("not a recognised config key", stderr.getvalue())
+
+    def test_cmd_config_empty_lists_supported_keys(self):
+        with (
+            mock.patch.object(self.remctl, "load_config", return_value={}),
+            contextlib.redirect_stdout(io.StringIO()) as stdout,
+        ):
+            self.remctl.cmd_config(SimpleNamespace(key=None, value=None, json=False))
+        out = stdout.getvalue()
+        self.assertIn("accountScope", out)
+        self.assertIn("storeDir", out)
+        self.assertIn("dbPath", out)
+
+    def test_apply_config_path_overrides_sets_store_dir(self):
+        """storeDir from config sets STORE_DIR when REMCTL_STORE_DIR is unset."""
+        import tempfile, json as _json
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            _json.dump({"storeDir": "/tmp/custom-stores"}, f)
+            cfg_path = f.name
+        try:
+            self.remctl.CONFIG_FILE = Path(cfg_path)
+            self.remctl._apply_config_path_overrides()
+            self.assertEqual(str(self.remctl.STORE_DIR), "/tmp/custom-stores")
+        finally:
+            os.unlink(cfg_path)
+
+    def test_apply_config_path_overrides_sets_db_path(self):
+        import tempfile, json as _json
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            _json.dump({"dbPath": "/tmp/pinned.sqlite"}, f)
+            cfg_path = f.name
+        try:
+            self.remctl.CONFIG_FILE = Path(cfg_path)
+            self.remctl._apply_config_path_overrides()
+            self.assertEqual(str(self.remctl.DB_OVERRIDE), "/tmp/pinned.sqlite")
+        finally:
+            os.unlink(cfg_path)
+
+    def test_apply_config_path_overrides_env_wins_over_config(self):
+        """REMCTL_STORE_DIR env var takes precedence over config storeDir."""
+        import tempfile, json as _json
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            _json.dump({"storeDir": "/tmp/from-config"}, f)
+            cfg_path = f.name
+        try:
+            self.remctl.CONFIG_FILE = Path(cfg_path)
+            with mock.patch.dict(os.environ, {"REMCTL_STORE_DIR": "/tmp/from-env"}):
+                self.remctl.STORE_DIR = Path("/tmp/from-env")  # as resolve_store_dir would have set
+                self.remctl._apply_config_path_overrides()
+                # config must not override the env-derived value
+                self.assertEqual(str(self.remctl.STORE_DIR), "/tmp/from-env")
+        finally:
+            os.unlink(cfg_path)
+
+    # ── Group 18: first_command_token (global flag positioning) ──────────────
+
+    def test_first_command_token_account_before_command(self):
+        """--account NAME before the subcommand: NAME is not mistaken for the command."""
+        self.assertEqual(
+            self.remctl.first_command_token(["--account", "Work Exchange", "lists"]),
+            "lists",
+        )
+
+    def test_first_command_token_account_equals_form(self):
+        self.assertEqual(
+            self.remctl.first_command_token(["--account=Exchange", "today"]),
+            "today",
+        )
+
+    def test_first_command_token_all_accounts_before_command(self):
+        self.assertEqual(
+            self.remctl.first_command_token(["--all-accounts", "stats"]),
+            "stats",
+        )
+
+    def test_first_command_token_format_value_still_skipped(self):
+        """Regression: --format value is not mistaken for the command."""
+        self.assertEqual(
+            self.remctl.first_command_token(["--format", "table", "lists"]),
+            "lists",
+        )
+
+    def test_first_command_token_combined_global_flags(self):
+        self.assertEqual(
+            self.remctl.first_command_token(["--no-color", "--account", "iCloud", "show", "Work"]),
+            "show",
+        )
+
+    # ── Group 19: bridge_call returns a list (list_calendars) ────────────────
+
+    def test_bridge_call_returns_list_payload(self):
+        """bridge_call returns list payloads (e.g. list_calendars), not just dicts."""
+        fake_result = {"returncode": 0, "stdout": "[]", "stderr": "",
+                       "payload": [{"title": "Tasks", "calendarIdentifier": "CAL-1"}]}
+        with mock.patch.object(self.remctl, "bridge_call_result", return_value=fake_result):
+            result = self.remctl.bridge_call({"action": "list_calendars"})
+        self.assertIsInstance(result, list)
+        self.assertEqual(result[0]["calendarIdentifier"], "CAL-1")
+
+    def test_bridge_call_returns_dict_payload(self):
+        """bridge_call still returns dict payloads for normal actions."""
+        fake_result = {"returncode": 0, "stdout": "{}", "stderr": "",
+                       "payload": {"status": "created", "id": "X"}}
+        with mock.patch.object(self.remctl, "bridge_call_result", return_value=fake_result):
+            result = self.remctl.bridge_call({"action": "create"})
+        self.assertEqual(result["status"], "created")
+
+    # ── Group 20: serialization account fields & table column ────────────────
+
+    def test_list_to_dict_account_kwarg(self):
+        row = {"Z_PK": 1, "ZNAME": "Work", "ZCKIDENTIFIER": "CK-1"}
+        acct = self.remctl.Account("/tmp/x", "Exchange", "Exchange")
+        with_acct = self.remctl.list_to_dict(row, account=acct)
+        without = self.remctl.list_to_dict(row)
+        self.assertEqual(with_acct["account"], "Exchange")
+        self.assertEqual(with_acct["accountType"], "Exchange")
+        self.assertNotIn("account", without)
+
+    def test_list_ref_payload_account_kwarg(self):
+        row = {"Z_PK": 2, "ZNAME": "Tasks", "ZCKIDENTIFIER": "CK-2"}
+        acct = self.remctl.Account("/tmp/x", "iCloud", "iCloud")
+        with_acct = self.remctl.list_ref_payload(row, account=acct)
+        without = self.remctl.list_ref_payload(row)
+        self.assertEqual(with_acct["account"], "iCloud")
+        self.assertNotIn("account", without)
+
+    def test_fmt_table_account_column_present_when_tagged(self):
+        rows = [{"id": 1, "title": "A", "list": "", "due": "", "pri": "", "account": "iCloud"}]
+        out = self.remctl.fmt_table(rows)
+        self.assertIn("Account", out)
+        self.assertIn("iCloud", out)
+
+    def test_fmt_table_account_column_absent_when_untagged(self):
+        rows = [{"id": 1, "title": "A", "list": "", "due": "", "pri": ""}]
+        out = self.remctl.fmt_table(rows)
+        self.assertNotIn("Account", out)
+
+    def test_tag_account_helper(self):
+        acct = self.remctl.Account("/tmp/x", "Exchange", "Exchange")
+        multi = self.remctl._tag_account({"id": 1}, acct, True)
+        single = self.remctl._tag_account({"id": 2}, acct, False)
+        self.assertEqual(multi["account"], "Exchange")
+        self.assertEqual(multi["accountType"], "Exchange")
+        self.assertNotIn("account", single)
+
+    # ── Group 21: discovery edge cases ───────────────────────────────────────
+
+    def test_store_account_info_fallback_name_for_unsynced_account(self):
+        """A store whose account row has no ZNAME yet derives a fallback name."""
+        import tempfile
+        path = Path(tempfile.mkdtemp()) / "Data-ABCD1234-5678.sqlite"
+        db = sqlite3.connect(str(path))
+        db.execute("CREATE TABLE Z_PRIMARYKEY (Z_NAME TEXT, Z_ENT INTEGER, Z_MAX INTEGER)")
+        db.execute("INSERT INTO Z_PRIMARYKEY VALUES ('REMCDAccount', 14, 1)")
+        db.execute("CREATE TABLE ZREMCDOBJECT (Z_PK INTEGER, Z_ENT INTEGER, ZNAME TEXT)")
+        db.execute("INSERT INTO ZREMCDOBJECT (Z_PK, Z_ENT, ZNAME) VALUES (1, 14, NULL)")
+        db.execute("CREATE TABLE ZREMCDREPLICAMANAGER (Z_PK INTEGER, Z_ENT INTEGER, ZIDENTIFIER TEXT)")
+        db.execute("INSERT INTO ZREMCDREPLICAMANAGER VALUES (1, 15, 'EE402AA3-1111/com.apple.exchangesync.exchangesyncd')")
+        db.commit()
+        db.close()
+        try:
+            info = self.remctl._store_account_info(path)
+        finally:
+            os.unlink(path)
+            os.rmdir(path.parent)
+        self.assertIsNotNone(info)
+        name, acct_type = info
+        self.assertEqual(acct_type, "Exchange")
+        self.assertTrue(name)  # a non-empty fallback name was derived
+
+    def test_discover_accounts_includes_empty_store(self):
+        """A real account with zero reminders is still discovered (not filtered out)."""
+        import tempfile
+        store_dir = Path(tempfile.mkdtemp())
+        # one store with a valid account name but no reminders
+        path = store_dir / "Data-EMPTY1234-0000.sqlite"
+        db = sqlite3.connect(str(path))
+        db.execute("CREATE TABLE Z_PRIMARYKEY (Z_NAME TEXT, Z_ENT INTEGER, Z_MAX INTEGER)")
+        db.execute("INSERT INTO Z_PRIMARYKEY VALUES ('REMCDAccount', 14, 1)")
+        db.execute("CREATE TABLE ZREMCDOBJECT (Z_PK INTEGER, Z_ENT INTEGER, ZNAME TEXT)")
+        db.execute("INSERT INTO ZREMCDOBJECT (Z_PK, Z_ENT, ZNAME) VALUES (1, 14, 'NewAccount')")
+        db.execute("CREATE TABLE ZREMCDREPLICAMANAGER (Z_PK INTEGER, Z_ENT INTEGER, ZIDENTIFIER TEXT)")
+        db.execute("INSERT INTO ZREMCDREPLICAMANAGER VALUES (1, 15, 'uuid/com.apple.exchangesync.exchangesyncd')")
+        db.commit()
+        db.close()
+        try:
+            self.remctl._ACCOUNT_CACHE = None
+            with (
+                mock.patch.object(self.remctl, "STORE_DIR", store_dir),
+                mock.patch.object(self.remctl, "DB_OVERRIDE", None),
+                mock.patch.object(self.remctl, "reminders_store_access_error", return_value=None),
+            ):
+                accounts = self.remctl.discover_accounts(force_refresh=True)
+        finally:
+            os.unlink(path)
+            os.rmdir(store_dir)
+            self.remctl._ACCOUNT_CACHE = None
+        names = [a.name for a in accounts]
+        self.assertIn("NewAccount", names)
+
+    # ── Group 22: cmd_show / cmd_info cross-account via config ───────────────
+
+    def test_cmd_show_ambiguous_list_via_config_all(self):
+        """With config=all, show <name> present in two accounts reports ambiguity."""
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ex = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        ic_db = self._make_account_db("iCloud", "iCloud", [(1, "Tasks", "CK-1")])
+        ex_db = self._make_account_db("Exchange", "Exchange", [(1, "Tasks", "CK-2")])
+        try:
+            with (
+                self._multi_account_patch([(ic, ic_db), (ex, ex_db)]),
+                mock.patch.object(self.remctl, "load_config", return_value={"accountScope": "all"}),
+                contextlib.redirect_stderr(io.StringIO()) as stderr,
+                self.assertRaises(SystemExit),
+            ):
+                self.remctl.cmd_show(SimpleNamespace(list="Tasks", list_id=None, account=None,
+                                                     completed=False, json=False, format=None,
+                                                     verbose=False))
+            self.assertIn("multiple lists match", stderr.getvalue())
+        finally:
+            ic_db.close()
+            ex_db.close()
+
+    def test_cmd_info_with_account_routes_through_resolver(self):
+        """info --account Exchange resolves via the --account-aware resolver."""
+        fake_db = mock.Mock()
+        fake_row = {"Z_PK": 7, "ZTITLE": "ExInfo", "ZLIST": None,
+                    "ZCKIDENTIFIER": "X", "list_name": "Tasks"}
+        captured = {}
+
+        def fake_resolve(a):
+            captured["account"] = getattr(a, "account", None)
+            return fake_db, fake_row
+
+        with (
+            mock.patch.object(self.remctl, "_resolve_reminder_for_write", side_effect=fake_resolve),
+            mock.patch.object(self.remctl, "q_reminders", return_value=[]),
+            mock.patch.object(self.remctl, "q_attachments", return_value=[]),
+            mock.patch.object(self.remctl, "q_alarms", return_value=[]),
+            mock.patch.object(self.remctl, "q_hashtags", return_value=[]),
+            mock.patch.object(self.remctl, "q_rich_link", return_value=None),
+            mock.patch.object(self.remctl, "to_dict", return_value={"id": 7, "title": "ExInfo"}),
+            mock.patch.object(self.remctl, "hydrate_reminder_detail", side_effect=lambda db, d, i: d),
+            contextlib.redirect_stdout(io.StringIO()) as stdout,
+        ):
+            self.remctl.cmd_info(SimpleNamespace(id=7, account="Exchange", json=True))
+        self.assertEqual(captured["account"], "Exchange")
+        self.assertEqual(json.loads(stdout.getvalue())["title"], "ExInfo")
+
+    # ── Group 23: cmd_add account-aware write targeting ──────────────────────
+
+    def _add_args(self, **overrides):
+        base = dict(
+            title="X", list=None, list_id=None, notes=None, due=None, priority=None,
+            flag=False, tags=None, url=None, recurrence=None, alarm=None,
+            private=False, private_metadata=False, section=None, new_section=None,
+            subtask=None, image=None, grocery=False, json=False, account=None,
+        )
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def test_cmd_add_account_with_list_passes_calendar_identifier(self):
+        """add -l Tasks --account Exchange resolves a stable calendarIdentifier for create."""
+        icloud = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        exchange = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        create_payloads = []
+
+        def fake_bridge_call(data):
+            if data["action"] == "list_calendars":
+                return [{"title": "Tasks", "calendarIdentifier": "CAL-EX", "sourceTitle": "Exchange"},
+                        {"title": "Tasks", "calendarIdentifier": "CAL-IC", "sourceTitle": "iCloud"}]
+            if data["action"] == "create":
+                create_payloads.append(data)
+                return {"status": "created", "id": "NEW-1"}
+            return None
+
+        fake_db = mock.Mock()
+        fake_db.row_factory = None
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[icloud, exchange]),
+            mock.patch.object(sqlite3, "connect", side_effect=lambda *a, **k: fake_db),
+            mock.patch.object(self.remctl, "resolve_list_or_die",
+                              return_value={"id": 1, "title": "Tasks", "requested": "Tasks", "method": "exact"}),
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(self.remctl, "bridge_call", side_effect=fake_bridge_call),
+            mock.patch.object(self.remctl, "q_reminder_by_identifier", return_value=None),
+            mock.patch.object(self.remctl, "private_metadata_enabled", return_value=False),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_add(self._add_args(title="T", list="Tasks", account="Exchange"))
+        self.assertEqual(len(create_payloads), 1)
+        self.assertEqual(create_payloads[0].get("calendarIdentifier"), "CAL-EX")
+        self.assertEqual(create_payloads[0].get("account"), "Exchange")
+        self.assertNotIn("list", create_payloads[0])  # calendarIdentifier supersedes title
+
+    def test_cmd_add_account_no_list_picks_first_calendar_in_account(self):
+        """add --account Exchange with no list targets the first calendar in that account."""
+        exchange = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        create_payloads = []
+
+        def fake_bridge_call(data):
+            if data["action"] == "list_calendars":
+                return [{"title": "Other", "calendarIdentifier": "CAL-IC", "sourceTitle": "iCloud"},
+                        {"title": "Tasks", "calendarIdentifier": "CAL-EX", "sourceTitle": "Exchange"}]
+            if data["action"] == "create":
+                create_payloads.append(data)
+                return {"status": "created", "id": "NEW-2"}
+            return None
+
+        with (
+            mock.patch.object(self.remctl, "discover_accounts", return_value=[exchange]),
+            mock.patch.object(sqlite3, "connect", side_effect=lambda *a, **k: mock.Mock()),
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(self.remctl, "bridge_call", side_effect=fake_bridge_call),
+            mock.patch.object(self.remctl, "q_reminder_by_identifier", return_value=None),
+            mock.patch.object(self.remctl, "private_metadata_enabled", return_value=False),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_add(self._add_args(title="T", account="Exchange"))
+        self.assertEqual(len(create_payloads), 1)
+        self.assertEqual(create_payloads[0].get("calendarIdentifier"), "CAL-EX")
+
+    def test_cmd_add_ambiguous_list_without_account_exits(self):
+        """add -l Tasks with no --account when Tasks exists in two accounts errors."""
+        def fake_bridge_call(data):
+            if data["action"] == "list_calendars":
+                return [{"title": "Tasks", "calendarIdentifier": "CAL-A", "sourceTitle": "AcctA"},
+                        {"title": "Tasks", "calendarIdentifier": "CAL-B", "sourceTitle": "AcctB"}]
+            return {"status": "created", "id": "X"}
+
+        with (
+            mock.patch.object(self.remctl, "open_db", return_value=mock.Mock()),
+            mock.patch.object(self.remctl, "resolve_list_or_die",
+                              return_value={"id": 1, "title": "Tasks", "requested": "Tasks", "method": "exact"}),
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(self.remctl, "bridge_call", side_effect=fake_bridge_call),
+            mock.patch.object(self.remctl, "private_metadata_enabled", return_value=False),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit),
+        ):
+            self.remctl.cmd_add(self._add_args(title="T", list="Tasks", account=None))
+        self.assertIn("multiple accounts", stderr.getvalue())
+
+    def test_cmd_add_exchange_id_fallback_by_title(self):
+        """For Exchange (no ZCKIDENTIFIER), the numeric id is recovered by title after create."""
+        exchange = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        ex_db = self._make_account_db(
+            "Exchange", "Exchange", [(1, "Tasks", "CK-L1")],
+            reminders=[{"Z_PK": 42, "ZTITLE": "NewTask", "ZLIST": 1, "ZCKIDENTIFIER": None}],
+        )
+
+        def fake_bridge_call(data):
+            if data["action"] == "list_calendars":
+                return [{"title": "Tasks", "calendarIdentifier": "CAL-EX", "sourceTitle": "Exchange"}]
+            if data["action"] == "create":
+                return {"status": "created", "id": "EK-NEW"}
+            return None
+
+        try:
+            with (
+                mock.patch.object(self.remctl, "discover_accounts", return_value=[exchange]),
+                mock.patch.object(sqlite3, "connect",
+                                  side_effect=self._connect_by_path({"/tmp/ex.sqlite": ex_db})),
+                mock.patch.object(self.remctl, "resolve_list_or_die",
+                                  return_value={"id": 1, "title": "Tasks", "requested": "Tasks", "method": "exact"}),
+                mock.patch.object(self.remctl, "bridge_available", return_value=True),
+                mock.patch.object(self.remctl, "bridge_call", side_effect=fake_bridge_call),
+                mock.patch.object(self.remctl, "q_reminder_by_identifier", return_value=None),
+                mock.patch.object(self.remctl, "private_metadata_enabled", return_value=False),
+                mock.patch.object(self.remctl, "_REMINDER_COLUMN_CACHE", {}),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_add(self._add_args(title="NewTask", list="Tasks", account="Exchange", json=True))
+            payload = json.loads(stdout.getvalue())
+        finally:
+            ex_db.close()
+        self.assertEqual(payload.get("numericId"), 42)
+
+    # ── Group 24: multi-account human output shows account group headers ─────
+
+    def test_cmd_today_all_accounts_shows_account_group_headers(self):
+        """today --all-accounts human output groups items under bold account headers."""
+        from datetime import datetime
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ex = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        due_ts = self.remctl.to_ts(datetime.now())
+        ic_db = self._make_account_db("iCloud", "iCloud", [(1, "Reminders", "CK-1")],
+                                      reminders=[{"Z_PK": 1, "ZTITLE": "iThing", "ZLIST": 1, "ZDUEDATE": due_ts}])
+        ex_db = self._make_account_db("Exchange", "Exchange", [(1, "Tasks", "CK-2")],
+                                      reminders=[{"Z_PK": 1, "ZTITLE": "xThing", "ZLIST": 1, "ZDUEDATE": due_ts}])
+        try:
+            with (
+                self._multi_account_patch([(ic, ic_db), (ex, ex_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_today(SimpleNamespace(json=False, all_accounts=True, account=None,
+                                                      no_overdue=False, format=None))
+            out = self.remctl._strip_ansi(stdout.getvalue())
+        finally:
+            ic_db.close()
+            ex_db.close()
+        # Both account headers and both items (same Z_PK=1 in each, no collision corruption)
+        self.assertIn("iCloud", out)
+        self.assertIn("Exchange", out)
+        self.assertIn("iThing", out)
+        self.assertIn("xThing", out)
+
+    # ── Group 25: priority bucketing (Exchange/CalDAV full 1-9 range) ────────
+
+    def test_priority_bucket_ranges(self):
+        """priority_bucket maps the full iCalendar 1-9 range to canonical buckets."""
+        b = self.remctl.priority_bucket
+        self.assertEqual(b(0), "none")
+        self.assertEqual(b(None), "none")
+        for v in (1, 2, 3, 4):
+            self.assertEqual(b(v), "high", f"priority {v} should be high")
+        self.assertEqual(b(5), "medium")
+        for v in (6, 7, 8, 9):
+            self.assertEqual(b(v), "low", f"priority {v} should be low")
+
+    def test_pri_marker_apple_native_values_unchanged(self):
+        """Apple's native 1/5/9 still map to !!!/!!/! (backward compatible)."""
+        self.assertEqual(self.remctl.PRI[0], "")
+        self.assertEqual(self.remctl.PRI[1], "!!!")
+        self.assertEqual(self.remctl.PRI[5], "!!")
+        self.assertEqual(self.remctl.PRI[9], "!")
+
+    def test_pri_marker_exchange_intermediate_values(self):
+        """Exchange/CalDAV intermediate values resolve via range buckets."""
+        # high range 1-4
+        for v in (2, 3, 4):
+            self.assertEqual(self.remctl.PRI[v], "!!!", f"priority {v}")
+        # low range 6-8
+        for v in (6, 7, 8):
+            self.assertEqual(self.remctl.PRI[v], "!", f"priority {v}")
+
+    def test_pri_name_map_ranges(self):
+        """PRI_NAME buckets values for the JSON 'priority' field."""
+        self.assertEqual(self.remctl.PRI_NAME[3], "high")
+        self.assertEqual(self.remctl.PRI_NAME[5], "medium")
+        self.assertEqual(self.remctl.PRI_NAME[7], "low")
+        self.assertEqual(self.remctl.PRI_NAME[0], "none")
+
+    def test_pri_get_with_default_buckets(self):
+        """.get() (used by serialize_reminder) buckets too, honoring its default for none."""
+        self.assertEqual(self.remctl.PRI_NAME.get(3, "none"), "high")
+        self.assertEqual(self.remctl.PRI.get(3, ""), "!!!")
+        self.assertEqual(self.remctl.PRI_NAME.get(0, "none"), "none")
+
+    def test_color_priority_marks_exchange_high(self):
+        """_color_priority returns a non-empty marker for an Exchange high value (3)."""
+        prev = self.remctl.C.enabled
+        self.remctl.C.enabled = False  # no ANSI, so we compare plain text
+        try:
+            self.assertEqual(self.remctl._color_priority(3), "!!!")
+            self.assertEqual(self.remctl._color_priority(5), "!!")
+            self.assertEqual(self.remctl._color_priority(7), "!")
+            self.assertEqual(self.remctl._color_priority(0), "")
+        finally:
+            self.remctl.C.enabled = prev
+
+    def test_serialize_reminder_exchange_priority_is_high(self):
+        """A reminder stored with priority 3 (Exchange/To Do starred) serializes as 'high'."""
+        row = {
+            "Z_PK": 7, "ZTITLE": "Starred Task", "ZNOTES": None, "ZCOMPLETED": 0,
+            "ZFLAGGED": 0, "ZPRIORITY": 3, "ZISURGENTSTATEENABLEDFORCURRENTUSER": 0,
+            "ZDUEDATEDELTAALERTSDATA": None, "ZDUEDATE": None, "ZDISPLAYDATEDATE": None,
+            "ZALLDAY": 0, "ZCOMPLETIONDATE": None, "ZCREATIONDATE": None,
+            "ZPARENTREMINDER": None, "ZLIST": 1, "ZICSURL": None, "ZCKIDENTIFIER": None,
+            "list_name": "Tasks",
+            "recurrence_frequency": None, "recurrence_interval": None,
+            "recurrence_count": None, "recurrence_end_date": None,
+            "recurrence_days_of_week": None, "recurrence_days_of_month": None,
+            "recurrence_months_of_year": None, "recurrence_days_of_year": None,
+            "recurrence_weeks_of_year": None, "recurrence_set_positions": None,
+        }
+        payload = self.remctl.to_dict(row, db=None)
+        self.assertEqual(payload["priority"], "high")
+        # And not flagged — confirms starred maps to priority, not the flag
+        self.assertFalse(payload["flagged"])
+
+    def test_fmt_shows_exchange_high_priority_marker(self):
+        """fmt() renders the !!! marker for an Exchange high-priority reminder."""
+        row = {
+            "Z_PK": 7, "ZTITLE": "Starred", "ZNOTES": None, "ZCOMPLETED": 0,
+            "ZFLAGGED": 0, "ZPRIORITY": 3, "ZISURGENTSTATEENABLEDFORCURRENTUSER": 0,
+            "ZDUEDATEDELTAALERTSDATA": None, "ZDUEDATE": None, "ZDISPLAYDATEDATE": None,
+            "ZALLDAY": 0, "ZCOMPLETIONDATE": None, "ZCREATIONDATE": None,
+            "ZPARENTREMINDER": None, "ZLIST": 1, "ZICSURL": None, "ZCKIDENTIFIER": None,
+            "list_name": "Tasks",
+        }
+        prev = self.remctl.C.enabled
+        self.remctl.C.enabled = False
+        try:
+            line = self.remctl.fmt(row, db=None)
+        finally:
+            self.remctl.C.enabled = prev
+        self.assertIn("!!!", line)
+
+    # ── Group 26: flag/unflag on non-iCloud accounts + _ek_identifier case ───
+
+    def test_cmd_flag_exchange_reminder_refuses_with_honest_error(self):
+        """flag on a reminder with no ZCKIDENTIFIER (Exchange) errors honestly, no fake success."""
+        fake_db = mock.Mock()
+        fake_row = {"ZCKIDENTIFIER": None, "ZTITLE": "Test_CAT1",
+                    "list_name": "Tasks", "ZLIST": 1, "ZDUEDATE": None}
+        with (
+            mock.patch.object(self.remctl, "_resolve_reminder_for_write",
+                              return_value=(fake_db, fake_row)),
+            mock.patch.object(self.remctl, "osa_by_id_try") as osa_mock,
+            mock.patch.object(self.remctl, "bridge_call") as bridge_call,
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit),
+        ):
+            self.remctl.cmd_flag(SimpleNamespace(id=2, json=False, account="Work Exchange"))
+        err = stderr.getvalue()
+        self.assertIn("no flag attribute", err)
+        self.assertIn("priority", err)
+        # Must NOT have attempted AppleScript or the misleading bridge proxy
+        osa_mock.assert_not_called()
+        bridge_call.assert_not_called()
+
+    def test_cmd_unflag_exchange_reminder_refuses_with_honest_error(self):
+        """unflag on a no-ZCKIDENTIFIER reminder errors honestly."""
+        fake_db = mock.Mock()
+        fake_row = {"ZCKIDENTIFIER": None, "ZTITLE": "Test_CAT1",
+                    "list_name": "Tasks", "ZLIST": 1, "ZDUEDATE": None}
+        with (
+            mock.patch.object(self.remctl, "_resolve_reminder_for_write",
+                              return_value=(fake_db, fake_row)),
+            mock.patch.object(self.remctl, "osa_by_id_try") as osa_mock,
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit),
+        ):
+            self.remctl.cmd_unflag(SimpleNamespace(id=2, json=False, account="Exchange"))
+        self.assertIn("no flag attribute", stderr.getvalue())
+        osa_mock.assert_not_called()
+
+    def test_cmd_flag_icloud_reminder_uses_applescript(self):
+        """flag on an iCloud reminder (ZCKIDENTIFIER present) sets the real flag via AppleScript."""
+        fake_db = mock.Mock()
+        fake_row = {"ZCKIDENTIFIER": "CK-IC-1", "ZTITLE": "iThing",
+                    "list_name": "Reminders", "ZLIST": 1, "ZDUEDATE": None}
+        with (
+            mock.patch.object(self.remctl, "_resolve_reminder_for_write",
+                              return_value=(fake_db, fake_row)),
+            mock.patch.object(self.remctl, "osa_by_id_try", return_value=True) as osa_mock,
+            contextlib.redirect_stdout(io.StringIO()) as stdout,
+        ):
+            self.remctl.cmd_flag(SimpleNamespace(id=1, json=False, account=None))
+        osa_mock.assert_called_once()
+        self.assertIn("set flagged of r to true", osa_mock.call_args.args[2])
+        self.assertIn("Flagged", stdout.getvalue())
+
+    def test_ek_identifier_account_match_is_case_insensitive(self):
+        """_ek_identifier matches the account hint case-insensitively."""
+        r = {"ZCKIDENTIFIER": None, "list_name": "Tasks", "ZTITLE": "T"}
+
+        def fake_bridge_call(data):
+            if data["action"] == "list_calendars":
+                return [{"title": "Tasks", "calendarIdentifier": "CAL-X",
+                         "sourceTitle": "Work Exchange"}]
+            if data["action"] == "find_reminder":
+                self.assertEqual(data["calendarIdentifier"], "CAL-X")
+                return {"calendarItemIdentifier": "EK-1"}
+            return None
+
+        with (
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(self.remctl, "bridge_call", side_effect=fake_bridge_call),
+        ):
+            # lowercase account hint must still match the canonical-cased sourceTitle
+            result = self.remctl._ek_identifier(r, account_name="work exchange")
+        self.assertEqual(result, "EK-1")
+
+    def test_ek_identifier_refuses_wrong_account_when_name_collides(self):
+        """When the account hint matches no calendar of that name, return None (no wrong-account guess)."""
+        r = {"ZCKIDENTIFIER": None, "list_name": "Tasks", "ZTITLE": "T"}
+
+        def fake_bridge_call(data):
+            if data["action"] == "list_calendars":
+                return [{"title": "Tasks", "calendarIdentifier": "CAL-A", "sourceTitle": "AcctA"},
+                        {"title": "Tasks", "calendarIdentifier": "CAL-B", "sourceTitle": "AcctB"}]
+            # find_reminder must never be called with a wrong calendar
+            raise AssertionError("find_reminder should not be called when account does not match")
+
+        with (
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(self.remctl, "bridge_call", side_effect=fake_bridge_call),
+        ):
+            result = self.remctl._ek_identifier(r, account_name="AcctC")  # not present
+        self.assertIsNone(result)
+
+    def test_ek_identifier_ambiguous_without_account_returns_none(self):
+        """Same list name in two accounts and no account hint → None (don't guess)."""
+        r = {"ZCKIDENTIFIER": None, "list_name": "Tasks", "ZTITLE": "T"}
+
+        def fake_bridge_call(data):
+            if data["action"] == "list_calendars":
+                return [{"title": "Tasks", "calendarIdentifier": "CAL-A", "sourceTitle": "AcctA"},
+                        {"title": "Tasks", "calendarIdentifier": "CAL-B", "sourceTitle": "AcctB"}]
+            raise AssertionError("find_reminder should not be called when ambiguous")
+
+        with (
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(self.remctl, "bridge_call", side_effect=fake_bridge_call),
+        ):
+            result = self.remctl._ek_identifier(r, account_name=None)
+        self.assertIsNone(result)
+
+    # ── Group 27: multi-account --format table preserves rich rows ───────────
+
+    def test_gather_table_rows_multi_has_rich_fields_and_account(self):
+        """Multi-account table rows keep id/due/repeat formatting AND add an account column."""
+        from datetime import datetime
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ex = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        due_ts = self.remctl.to_ts(datetime.now())
+        ic_db = self._make_account_db("iCloud", "iCloud", [(1, "Reminders", "CK-1")],
+                                      reminders=[{"Z_PK": 5, "ZTITLE": "iTask", "ZLIST": 1, "ZDUEDATE": due_ts}])
+        ex_db = self._make_account_db("Exchange", "Exchange", [(1, "Tasks", "CK-2")],
+                                      reminders=[{"Z_PK": 9, "ZTITLE": "xTask", "ZLIST": 1, "ZDUEDATE": due_ts}])
+        try:
+            with self._multi_account_patch([(ic, ic_db), (ex, ex_db)]):
+                rows = self.remctl.gather_table_rows(
+                    [ic, ex], lambda db: self.remctl.q_due_today(db, include_overdue=True)
+                )
+        finally:
+            ic_db.close()
+            ex_db.close()
+        self.assertEqual(len(rows), 2)
+        for row in rows:
+            # rich table shape: id carries the '#', due is populated, account present
+            self.assertIn("#", self.remctl._strip_ansi(str(row["id"])))
+            self.assertIn("due", row)
+            self.assertIn(row["account"], {"iCloud", "Exchange"})
+
+    def test_gather_table_rows_single_account_has_no_account_key(self):
+        """Single-account table rows must not carry an account key (byte-compat)."""
+        from datetime import datetime
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        due_ts = self.remctl.to_ts(datetime.now())
+        ic_db = self._make_account_db("iCloud", "iCloud", [(1, "Reminders", "CK-1")],
+                                      reminders=[{"Z_PK": 5, "ZTITLE": "iTask", "ZLIST": 1, "ZDUEDATE": due_ts}])
+        try:
+            with self._multi_account_patch([(ic, ic_db)]):
+                rows = self.remctl.gather_table_rows(
+                    [ic], lambda db: self.remctl.q_due_today(db, include_overdue=True)
+                )
+        finally:
+            ic_db.close()
+        self.assertEqual(len(rows), 1)
+        self.assertNotIn("account", rows[0])
+
+    def test_cmd_today_all_accounts_table_populates_due_column(self):
+        """Regression: today --all-accounts --format table must populate Due (not blank)."""
+        from datetime import datetime
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ex = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        due_ts = self.remctl.to_ts(datetime.now())
+        ic_db = self._make_account_db("iCloud", "iCloud", [(1, "Reminders", "CK-1")],
+                                      reminders=[{"Z_PK": 5, "ZTITLE": "iTask", "ZLIST": 1, "ZDUEDATE": due_ts}])
+        ex_db = self._make_account_db("Exchange", "Exchange", [(1, "Tasks", "CK-2")],
+                                      reminders=[{"Z_PK": 9, "ZTITLE": "xTask", "ZLIST": 1, "ZDUEDATE": due_ts}])
+        try:
+            with (
+                self._multi_account_patch([(ic, ic_db), (ex, ex_db)]),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_today(SimpleNamespace(json=False, all_accounts=True, account=None,
+                                                      no_overdue=False, format="table"))
+            out = self.remctl._strip_ansi(stdout.getvalue())
+        finally:
+            ic_db.close()
+            ex_db.close()
+        self.assertIn("Today", out)       # Due column populated, not blank
+        self.assertIn("Account", out)     # account column present
+        self.assertIn("#5", out)          # id keeps the # prefix
+        self.assertIn("#9", out)
+
+    # ── Group 28: single-account scope (--account) must not add labels ───────
+
+    def test_cmd_lists_single_account_scope_no_labels(self):
+        """lists --account X (one account in scope) emits no account field/column — byte-compat."""
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ic_db = self._make_account_db("iCloud", "iCloud", [(1, "Reminders", "CK-1")])
+        try:
+            # JSON: no account field
+            with (self._multi_account_patch([(ic, ic_db)]),
+                  contextlib.redirect_stdout(io.StringIO()) as out):
+                self.remctl.cmd_lists(SimpleNamespace(json=True, all_accounts=False, account="iCloud"))
+            payload = json.loads(out.getvalue())
+            self.assertTrue(payload)
+            for item in payload:
+                self.assertNotIn("account", item)
+            # table: no Account column
+            with (self._multi_account_patch([(ic, ic_db)]),
+                  contextlib.redirect_stdout(io.StringIO()) as out2):
+                self.remctl.cmd_lists(SimpleNamespace(json=False, all_accounts=False,
+                                                      account="iCloud", format="table"))
+            self.assertNotIn("Account", out2.getvalue())
+        finally:
+            ic_db.close()
+
+    def test_cmd_stats_single_account_scope_flat_json_and_heading(self):
+        """stats --account X (one account) uses the flat JSON + 'Reminders Stats' heading (byte-compat)."""
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ic_db = self._make_account_db("iCloud", "iCloud", [(1, "Reminders", "CK-1")],
+                                      reminders=[{"Z_PK": 1, "ZTITLE": "x", "ZLIST": 1}])
+        try:
+            with (self._multi_account_patch([(ic, ic_db)]),
+                  mock.patch.object(self.remctl, "_REMINDER_COLUMN_CACHE", {}),
+                  contextlib.redirect_stdout(io.StringIO()) as out):
+                self.remctl.cmd_stats(SimpleNamespace(json=True, all_accounts=False, account="iCloud"))
+            payload = json.loads(out.getvalue())
+            # flat structure (original), NOT nested {"total": {...}, "accounts": {...}}
+            self.assertIsInstance(payload["total"], int)
+            self.assertNotIn("accounts", payload)
+            with (self._multi_account_patch([(ic, ic_db)]),
+                  mock.patch.object(self.remctl, "_REMINDER_COLUMN_CACHE", {}),
+                  contextlib.redirect_stdout(io.StringIO()) as out2):
+                self.remctl.cmd_stats(SimpleNamespace(json=False, all_accounts=False, account="iCloud"))
+            self.assertIn("Reminders Stats", out2.getvalue())
+            self.assertNotIn("Stats: iCloud", out2.getvalue())
+        finally:
+            ic_db.close()
+
+    def test_cmd_search_single_account_scope_no_indent(self):
+        """search --account X (one account) does not indent results — matches original flat format."""
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ic_db = self._make_account_db("iCloud", "iCloud", [(1, "Reminders", "CK-1")],
+                                      reminders=[{"Z_PK": 1, "ZTITLE": "findme", "ZLIST": 1}])
+        try:
+            with (self._multi_account_patch([(ic, ic_db)]),
+                  contextlib.redirect_stdout(io.StringIO()) as out):
+                self.remctl.cmd_search(SimpleNamespace(json=False, all_accounts=False, account="iCloud",
+                                                       query="findme", completed=False, verbose=False,
+                                                       format=None))
+            lines = [l for l in self.remctl._strip_ansi(out.getvalue()).splitlines()
+                     if "findme" in l]
+            self.assertTrue(lines)
+            for l in lines:
+                self.assertFalse(l.startswith("  "), f"single-account search must not indent: {l!r}")
+        finally:
+            ic_db.close()
+
+
+    # ── Group 29: global account-flag strictness for non-account commands ────
+
+    def test_global_account_flag_rejected_for_non_account_command(self):
+        """--account before a non-account command (doctor) errors strictly (rc 2)."""
+        with (
+            mock.patch.object(sys, "argv", ["remctl", "--account", "iCloud", "doctor"]),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit) as raised,
+        ):
+            self.remctl.main()
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("does not support", stderr.getvalue())
+
+    def test_global_all_accounts_flag_rejected_for_non_account_command(self):
+        """--all-accounts before a non-account command (accounts) errors strictly."""
+        with (
+            mock.patch.object(sys, "argv", ["remctl", "--all-accounts", "accounts"]),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit) as raised,
+        ):
+            self.remctl.main()
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("does not support", stderr.getvalue())
+
+    def test_all_accounts_rejected_for_single_account_command(self):
+        """A command that supports --account but does not aggregate (export) rejects
+        --all-accounts rather than silently ignoring it (per-flag strictness)."""
+        with (
+            mock.patch.object(sys, "argv", ["remctl", "--all-accounts", "export"]),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit) as raised,
+        ):
+            self.remctl.main()
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("does not support --all-accounts", stderr.getvalue())
+
+    # ── Group 30: smart-lists / templates multi-account aggregation ──────────
+
+    def test_cmd_smart_lists_single_account_no_account_field(self):
+        """smart-lists --account X (single) emits no account field — byte-compat with original."""
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ic_db = self._make_account_db("iCloud", "iCloud", [])
+        try:
+            with (self._multi_account_patch([(ic, ic_db)]),
+                  contextlib.redirect_stdout(io.StringIO()) as out):
+                self.remctl.cmd_smart_lists(SimpleNamespace(json=True, all_accounts=False, account="iCloud"))
+            payload = json.loads(out.getvalue())
+            for item in payload:
+                self.assertNotIn("account", item)
+        finally:
+            ic_db.close()
+
+    def test_cmd_smart_lists_all_accounts_runs_and_tags_when_multi(self):
+        """smart-lists --all-accounts aggregates across accounts (valid JSON, account-tagged)."""
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ex = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        ic_db = self._make_account_db("iCloud", "iCloud", [])
+        ex_db = self._make_account_db("Exchange", "Exchange", [])
+        try:
+            with (self._multi_account_patch([(ic, ic_db), (ex, ex_db)]),
+                  contextlib.redirect_stdout(io.StringIO()) as out):
+                self.remctl.cmd_smart_lists(SimpleNamespace(json=True, all_accounts=True, account=None))
+            payload = json.loads(out.getvalue())  # must be valid JSON (list), no crash
+            self.assertIsInstance(payload, list)
+        finally:
+            ic_db.close()
+            ex_db.close()
+
+    def test_cmd_templates_all_accounts_aggregates_and_tags(self):
+        """templates --all-accounts aggregates per account and tags each with its account."""
+        ic = self.remctl.Account("/tmp/ic.sqlite", "iCloud", "iCloud")
+        ex = self.remctl.Account("/tmp/ex.sqlite", "Exchange", "Exchange")
+        ic_db = self._make_account_db("iCloud", "iCloud", [])
+        ex_db = self._make_account_db("Exchange", "Exchange", [])
+        # q_templates is unchanged code needing extra schema; mock it to focus on
+        # cmd_templates' multi-account aggregation wiring. Return one row for iCloud.
+        def fake_q_templates(db):
+            return [{"_ck": "T1"}] if db is ic_db else []
+        try:
+            with (
+                self._multi_account_patch([(ic, ic_db), (ex, ex_db)]),
+                mock.patch.object(self.remctl, "q_templates", side_effect=fake_q_templates),
+                mock.patch.object(self.remctl, "template_to_dict",
+                                  side_effect=lambda row: {"id": 1, "name": "Tmpl", "itemCount": 0}),
+                contextlib.redirect_stdout(io.StringIO()) as out,
+            ):
+                self.remctl.cmd_templates(SimpleNamespace(json=True, all_accounts=True, account=None))
+            payload = json.loads(out.getvalue())
+            self.assertEqual(len(payload), 1)
+            self.assertEqual(payload[0]["account"], "iCloud")  # tagged with its account
+        finally:
+            ic_db.close()
+            ex_db.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

RemCTL currently reads from a single Reminders store chosen by file size.
On setups with more than one account (iCloud + Exchange/CalDAV + on-device),
the largest file is often a bloated Exchange store rather than the live
iCloud one, so RemCTL silently operates on the wrong account.

This PR fixes store selection and, on top of that, adds **opt-in**
multi-account support: read from every connected account, see which account
each item belongs to, and create/modify/delete in any of them. The default
behavior is unchanged and single-account output is byte-for-byte identical.

## Motivation

`find_main_db_path()` selected the store with the largest file on disk.
Exchange stores accumulate size independent of how many live reminders they
hold, so the heuristic can pick a stale/secondary account. The result is
confusing: `today`, `lists`, etc. show an account the user didn't expect.

## What changed

**Store selection**
- Choose the active store by reminder count, then file-group recency.
- `REMCTL_DB` env var / `dbPath` config key to pin a specific file;
  `REMCTL_STORE_DIR` / `storeDir` to point at a Stores directory.

**Reading across accounts (opt-in)**
- `--all-accounts` includes every connected account; `--account NAME`
  restricts to one. A personal default can be set with
  `REMCTL_ACCOUNT_SCOPE` or the `accountScope` config key (`all` or a name).
- Source labelling: bold per-account headers (human), `account` /
  `accountType` fields (JSON), an Account column (table).
- IDs (`Z_PK`) are per-account; when the scope spans accounts, an ID or
  list name found in more than one produces a disambiguation error that
  lists candidates and asks for `--account`.
- New `accounts` command (lists connected accounts) and `config` command
  (`accountScope` / `storeDir` / `dbPath`).

**Writing to a specific account**
- The EventKit bridge gains a `list_calendars` action and targets lists by
  stable calendar identifier, so a `(list, account)` pair resolves to the
  right calendar instead of an arbitrarily-chosen same-named list.
- `--account` on `add` / `done` / `edit` / `delete` / `flag`, etc.
- :warning: **The bridge must be recompiled** after pulling this change:
  `./install.sh` (runs `swiftc -O`).

**Correctness fix**
- `stats` counted overdue against the current time, so reminders due earlier
  *today* were reported as overdue even though `overdue` itself lists none.
  It now counts from the start of the day, matching `overdue` and `today`.

**Deliberate scope limit**
- `export` / `import` operate on a single account (reminder IDs collide
  across accounts). They accept `--account` but refuse an all-accounts
  scope with a clear error rather than writing a silently partial backup.

## Backward compatibility

Single-account behavior is the default. With no flags/config, output is
byte-for-byte identical to the previous release — verified by diffing every
read command × format (plain/table/json) against `main`, for both the
default scope and an explicit `--account`. The only intended output change
is the `stats` overdue fix above.

## Testing

- `python3 -m pytest tests/test_cli.py` -> **273 passing**, plus coverage for
  account discovery, scope precedence, cross-account addressing/ambiguity,
  and single-account back-compat.
- One pre-existing failure,
  `test_info_json_keeps_due_date_separate_from_display_alarm_date`, is
  **not** introduced here — it fails identically on unmodified `main`
  because it hard-codes a UTC+2 expected value and only passes in that
  timezone. Happy to fix it (force a fixed TZ) in a separate change if you'd
  like.

## Notes for review

- One PR intentionally bundles the Python CLI and the Swift bridge because
  account-targeted writes need both.
- No third-party dependencies added.
