### PR TITLE
Print zsh fpath snippet after setup and verify it in doctor

### DIFF
--- a/remctl
+++ b/remctl
@@ -7951,6 +7951,13 @@ def cmd_setup(a):
             print(f"Shell completion: {completion_path}")
         else:
             print("Shell completion: skipped")
+        if selected_shell == "zsh" and completion_path:
+            print()
+            print(C.bold("Enable zsh completions:"))
+            print("  Add these lines to ~/.zshrc, then open a new terminal:")
+            print(f"    fpath=({completion_path.parent} $fpath)")
+            print("    autoload -Uz compinit && compinit")
+            print(C.dim("  Skip if your config already adds ~/.zsh/completions to fpath."))
         print()
         print("Next:")
         print("  1. remctl onboard   # trigger macOS Reminders and Automation prompts")

--- a/remctl
+++ b/remctl
@@ -7381,6 +7381,31 @@ def install_completion(shell):
     return target
 
 
+def zsh_completion_loadable(completion_path):
+    target = completion_path.parent.resolve()
+    try:
+        result = subprocess.run(
+            ["zsh", "-i", "-c", "print -rl -- $fpath"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        candidate = line.strip()
+        if not candidate:
+            continue
+        try:
+            if Path(candidate).resolve() == target:
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def resolve_setup_shell(requested_shell):
     if requested_shell != "auto":
         return requested_shell
@@ -7815,12 +7840,24 @@ def gather_doctor_checks():
     shell = detect_shell_name()
     if shell in {"zsh", "bash", "fish"}:
         completion_path = completion_target_path(shell)
+        completion_exists = completion_path.exists()
         add(
             "completion",
-            "ok" if completion_path.exists() else "warn",
+            "ok" if completion_exists else "warn",
             f"{shell}: {completion_path}",
-            None if completion_path.exists() else f"Run remctl setup --shell {shell} to install completion.",
+            None if completion_exists else f"Run remctl setup --shell {shell} to install completion.",
         )
+        if shell == "zsh" and completion_exists:
+            loadable = zsh_completion_loadable(completion_path)
+            if loadable is True:
+                add("completion_fpath", "ok", f"{completion_path.parent} is on $fpath", None)
+            elif loadable is False:
+                add(
+                    "completion_fpath",
+                    "warn",
+                    f"{completion_path.parent} is not on $fpath",
+                    f"Add to ~/.zshrc:\n    fpath=({completion_path.parent} $fpath)\n    autoload -Uz compinit && compinit",
+                )
     else:
         add("completion", "warn", f"Unsupported shell '{shell}'", "Run remctl setup --shell zsh|bash|fish.")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2832,47 +2832,6 @@ class CliTests(unittest.TestCase):
         self.assertIn("Shell completion: skipped", output)
         self.assertIn("remctl onboard", output)
 
-    def test_cmd_setup_prints_zsh_fpath_hint(self):
-        args = SimpleNamespace(
-            shell="zsh",
-            doctor=False,
-            json=False,
-        )
-        with tempfile.TemporaryDirectory() as tmpdir:
-            completion_path = Path(tmpdir) / "completions" / "_remctl"
-            with (
-                mock.patch.object(self.remctl, "CONFIG_DIR", Path(tmpdir) / "config"),
-                mock.patch.object(
-                    self.remctl, "install_completion", return_value=completion_path
-                ),
-                contextlib.redirect_stdout(io.StringIO()) as stdout,
-            ):
-                self.remctl.cmd_setup(args)
-        output = stdout.getvalue()
-        self.assertIn("Enable zsh completions:", output)
-        self.assertIn(f"fpath=({completion_path.parent} $fpath)", output)
-        self.assertIn("autoload -Uz compinit && compinit", output)
-
-    def test_cmd_setup_omits_zsh_hint_for_other_shells(self):
-        args = SimpleNamespace(
-            shell="fish",
-            doctor=False,
-            json=False,
-        )
-        with tempfile.TemporaryDirectory() as tmpdir:
-            completion_path = Path(tmpdir) / "completions" / "remctl.fish"
-            with (
-                mock.patch.object(self.remctl, "CONFIG_DIR", Path(tmpdir) / "config"),
-                mock.patch.object(
-                    self.remctl, "install_completion", return_value=completion_path
-                ),
-                contextlib.redirect_stdout(io.StringIO()) as stdout,
-            ):
-                self.remctl.cmd_setup(args)
-        output = stdout.getvalue()
-        self.assertNotIn("Enable zsh completions:", output)
-        self.assertNotIn("compinit", output)
-
     def test_cmd_upcoming_rejects_non_positive_days_before_database_read(self):
         for days in (0, -1):
             args = SimpleNamespace(days=days, json=True, verbose=False, format="json")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2832,6 +2832,47 @@ class CliTests(unittest.TestCase):
         self.assertIn("Shell completion: skipped", output)
         self.assertIn("remctl onboard", output)
 
+    def test_cmd_setup_prints_zsh_fpath_hint(self):
+        args = SimpleNamespace(
+            shell="zsh",
+            doctor=False,
+            json=False,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            completion_path = Path(tmpdir) / "completions" / "_remctl"
+            with (
+                mock.patch.object(self.remctl, "CONFIG_DIR", Path(tmpdir) / "config"),
+                mock.patch.object(
+                    self.remctl, "install_completion", return_value=completion_path
+                ),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_setup(args)
+        output = stdout.getvalue()
+        self.assertIn("Enable zsh completions:", output)
+        self.assertIn(f"fpath=({completion_path.parent} $fpath)", output)
+        self.assertIn("autoload -Uz compinit && compinit", output)
+
+    def test_cmd_setup_omits_zsh_hint_for_other_shells(self):
+        args = SimpleNamespace(
+            shell="fish",
+            doctor=False,
+            json=False,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            completion_path = Path(tmpdir) / "completions" / "remctl.fish"
+            with (
+                mock.patch.object(self.remctl, "CONFIG_DIR", Path(tmpdir) / "config"),
+                mock.patch.object(
+                    self.remctl, "install_completion", return_value=completion_path
+                ),
+                contextlib.redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.remctl.cmd_setup(args)
+        output = stdout.getvalue()
+        self.assertNotIn("Enable zsh completions:", output)
+        self.assertNotIn("compinit", output)
+
     def test_cmd_upcoming_rejects_non_positive_days_before_database_read(self):
         for days in (0, -1):
             args = SimpleNamespace(days=days, json=True, verbose=False, format="json")


### PR DESCRIPTION
Fixes #7.

## Summary
- When `remctl setup` installs zsh completions, print the exact `fpath=(...)` + `autoload -Uz compinit && compinit` snippet the user needs in `~/.zshrc` for the completion to actually load. Only fires for `shell == zsh` and when a completion path was written. JSON output unchanged.
- Add a `completion_fpath` check to `remctl doctor` that probes `zsh -i -c 'print -rl -- \$fpath'` and warns (with the same snippet as a fix) when the zsh completion install dir is not on the user's `fpath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)