### PR TITLE
Support explicit completion dates for done

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -66,6 +66,7 @@ remctl edit 23880 -l Work --json
 remctl edit 23880 --list-id 156 --json
 remctl edit 23880 --recurrence monthly --json
 remctl done 23880 --json
+remctl done 23880 --date 2026-05-27 --json
 remctl link --list-id 153 --json
 remctl export --list-id 153 --format json
 remctl list-symbols --preview
@@ -223,6 +224,7 @@ remctl template-delete "Packing Template" --private --force --json
 - Prefer deterministic due-date strings. If the user says "today at 3pm", either pass `today at 3pm` or normalize it to `YYYY-MM-DD HH:MM` in the user's timezone before calling `remctl`; do not invent broader natural-language phrases.
 - `add` and `edit` are atomic for due dates: if `-d/--due` is present and cannot be parsed, RemCTL exits before writing. With `--json`, parse failures are structured `invalid_due_date` errors on stderr with accepted examples. Retry with a corrected date instead of creating first and patching later.
 - Accepted dependency-free due-date forms include `YYYY-MM-DD`, `YYYY-MM-DD HH:MM`, `today at 3pm`, `tomorrow 09:30`, `tonight at 11`, `Friday at 15:00`, `next friday at 3pm`, `+3d`, `eod`, and `eow`.
+- `remctl done ID --date WHEN --json` sets a completion date (also works on an already-completed reminder, to correct it); WHEN is an absolute date (`2026-05-27`) or datetime (`2026-05-27 09:30`), a bare date meaning midnight. It is rejected for recurring reminders: use plain `done` (without `--date`) instead.
 - `dueDate` in JSON is the actual Reminders due date from `ZDUEDATE`. If Reminders stores a separate UI/alert display date, including all-day display dates, RemCTL reports it separately as `displayDate`.
 - For ordinary rescheduling, use `remctl edit ID -d "YYYY-MM-DD HH:MM" --json` first. When a reminder has a single absolute alarm/display time equal to the old due time, RemCTL carries that alarm forward so Reminders.app does not keep showing the old time. `edit ID -d clear --json` also removes a single matching absolute alarm/display time so the item does not stay visible under the old time.
 - When debugging due-date or alarm mismatches, compare `dueDate`, `displayDate`, and `alarms` before assuming the CLI or UI is wrong.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -158,6 +158,8 @@ Location alarms are normal reminder alarms saved through EventKit structured-loc
 
 ```bash
 remctl done 23880
+remctl done 23880 --date 2026-05-27
+remctl done 23880 --date "2026-05-27 09:30"
 remctl undone 23880
 remctl edit 23880 --title "New title"
 remctl edit 23880 -d "next friday" -p medium
@@ -170,6 +172,8 @@ remctl unflag 23880
 remctl delete 23880
 remctl delete 23880 --force
 ```
+
+`done --date WHEN` sets a completion date instead of stamping it with the current date & time, and also works on an already-completed reminder to correct its completion date. `WHEN` is an absolute date (`2026-05-27`) or datetime (`2026-05-27 09:30`); a bare date records midnight of that day. It is rejected for recurring reminders: use plain `done` (without `--date`) instead.
 
 ## Lists
 

--- a/remctl
+++ b/remctl
@@ -4161,7 +4161,7 @@ def invalid_due_date_payload(value, field="due"):
         "code": "invalid_due_date",
         "field": field,
         "input": value,
-        "message": "Could not parse due date. No reminder was created or changed.",
+        "message": "Could not parse date. No reminder was created or changed.",
         "examples": due_date_examples(),
     }
 
@@ -4170,7 +4170,7 @@ def fail_invalid_due_date(value, *, json_mode=False, field="due"):
     if json_mode:
         print(json.dumps(payload), file=sys.stderr)
     else:
-        print(f"Error: could not parse due date {value!r}.", file=sys.stderr)
+        print(f"Error: could not parse date {value!r}.", file=sys.stderr)
         print("No reminder was created or changed.", file=sys.stderr)
         print("", file=sys.stderr)
         print("Use exact forms like:", file=sys.stderr)
@@ -5646,6 +5646,33 @@ def _refuse_unsafe_title_fallback(reminder, operation, reason):
     )
     sys.exit(1)
 
+def osa_set_completion_date_script(dt):
+    """AppleScript statements (operating on `r`) that set its completion date to
+    dt. Built from components rather than a `date "..."` literal so it does not
+    depend on the system's locale date format."""
+    seconds_into_day = dt.hour * 3600 + dt.minute * 60 + dt.second
+    return (
+        "set d to current date\n"
+        "set day of d to 1\n"  # set day=1 first so changing month can't overflow
+        f"set year of d to {dt.year}\n"
+        f"set month of d to {dt.month}\n"
+        f"set day of d to {dt.day}\n"
+        f"set time of d to {seconds_into_day}\n"
+        "set completion date of r to d"
+    )
+
+def _bridge_completion_local_iso(iso_str):
+    """A bridge completion ISO ("…Z" UTC or with offset) as local-naive ISO,
+    matching how dueDate is serialized. None if absent; the raw string back if
+    it can't be parsed."""
+    if not iso_str:
+        return None
+    try:
+        local = datetime.fromisoformat(iso_str.replace("Z", "+00:00")).astimezone()
+        return local.replace(tzinfo=None).isoformat()
+    except ValueError:
+        return iso_str
+
 def cmd_done(a):
     db = open_db()
     r = q_reminder(db, a.id)
@@ -5653,25 +5680,85 @@ def cmd_done(a):
         print(f"Error: #{a.id} not found", file=sys.stderr)
         sys.exit(1)
 
+    # Look for dated completion parameter
+    want_date = getattr(a, "date", None)
+    done_iso = None
+    done_dt = None
+    if want_date:
+        done_dt = parse_due(want_date)
+        if not done_dt:
+            fail_invalid_due_date(want_date, json_mode=getattr(a, "json", False), field="date")
+        done_iso = done_dt.isoformat()
+
+    # Dating is refused for recurring reminders: otherwise completing one
+    # makes EventKit advance the series (rolling the due date forward from
+    # "now") and split off a completed occurrence, discarding any completionDate
+    # we set. Plain `done` (without --date) still advances the series correctly.
+    if done_iso and r["recurrence_frequency"] is not None:
+        message = (
+            "--date is not supported for recurring reminders. "
+            f"Use 'remctl done {a.id}' (without --date) to advance the series."
+        )
+        if getattr(a, "json", False):
+            print(json.dumps({
+                "status": "error", "code": "date_unsupported_for_recurring",
+                "message": message, "id": a.id,
+            }), file=sys.stderr)
+        else:
+            print(f"Error: {message}", file=sys.stderr)
+        sys.exit(1)
+
     # Bridge-first for speed (post-2026-04-17 bridge fix: dueDateComponents
     # now reach CloudKit correctly). AppleScript stays as a fallback.
     if bridge_available() and r["ZCKIDENTIFIER"]:
         data = {"action": "complete", "id": r["ZCKIDENTIFIER"]}
+        if done_iso:
+            data["completionDate"] = done_iso
         result = bridge_call(data)
         if result and result.get("status") == "completed":
             if a.json:
-                print(json.dumps({"status": "completed", "id": a.id, "title": r["ZTITLE"]}))
+                out = {"status": "completed", "id": a.id, "title": r["ZTITLE"]}
+                # Report completionDate as local-naive ISO like dueDate. For
+                # --date, echo what we sent (done_iso) so this matches the
+                # AppleScript path exactly; otherwise normalize the bridge's UTC
+                # stamp to local-naive.
+                cd_out = done_iso or _bridge_completion_local_iso(result.get("completionDate"))
+                if cd_out:
+                    out["completionDate"] = cd_out
+                print(json.dumps(out))
             else:
-                print(f"Completed: {safe_display(r['ZTITLE'])}")
+                when = ""
+                cd = result.get("completionDate")
+                if cd:
+                    # The bridge echoes the stored completion as UTC ISO; render
+                    # it in local time to match how `show` displays completions
+                    # (JSON reports the same instant as local-naive ISO).
+                    try:
+                        local = datetime.fromisoformat(cd.replace("Z", "+00:00")).astimezone()
+                        when = f" (completed {local.strftime('%b %d, %Y at %I:%M %p')})"
+                    except ValueError:
+                        when = f" (completed {cd})"
+                print(f"Completed: {safe_display(r['ZTITLE'])}{when}")
             return
 
-    # AppleScript fallback
+    # AppleScript fallback. The basic complete only marks the reminder done;
+    # when --date is given we additionally set its completion date (AppleScript
+    # can do this). The recurring guard above already excluded recurring
+    # reminders, so the target here is always non-recurring.
     rid = _rem_id(r)
-    if rid and osa_by_id_try(r["list_name"], rid, "set completed of r to true"):
+    action = "set completed of r to true"
+    if done_dt is not None:
+        action += "\n" + osa_set_completion_date_script(done_dt)
+    if rid and osa_by_id_try(r["list_name"], rid, action):
         if a.json:
-            print(json.dumps({"status": "completed", "id": a.id, "title": r["ZTITLE"]}))
+            out = {"status": "completed", "id": a.id, "title": r["ZTITLE"]}
+            if done_iso:
+                out["completionDate"] = done_iso
+            print(json.dumps(out))
         else:
-            print(f"Completed: {safe_display(r['ZTITLE'])}")
+            when = (f" (completed {done_dt.strftime('%b %d, %Y at %I:%M %p')})"
+                    if done_dt is not None else "")
+            print(f"Completed: {safe_display(r['ZTITLE'])}{when}")
         return
     if not rid:
         _refuse_unsafe_title_fallback(r, "complete it", "The reminder has no stable identifier")
@@ -8137,7 +8224,7 @@ def main():
     c.add_argument("--early-reminder", help="Private metadata: Early Reminder before due date, e.g. 15m, 1h, 2d, 1w, 1mo, or clear")
     js(c)
 
-    c = sub.add_parser("done", help="Complete a reminder"); c.add_argument("id", type=int); js(c)
+    c = sub.add_parser("done", help="Complete a reminder (or amend its completion date)"); c.add_argument("id", type=int); c.add_argument("--date", dest="date", metavar="WHEN", help="Set completion date to WHEN, an absolute YYYY-MM-DD or 'YYYY-MM-DD HH:MM' (date alone = midnight; also amends an already-completed reminder)"); js(c)
     c = sub.add_parser("undone", help="Uncomplete a reminder"); c.add_argument("id", type=int); js(c)
 
     c = sub.add_parser(

--- a/remctl-bridge.swift
+++ b/remctl-bridge.swift
@@ -25,6 +25,7 @@ struct Command: Decodable {
     let radius: Double?
     let proximity: String?
     let color: String?
+    let completionDate: String?
 }
 
 struct RecurrenceSpec: Decodable {
@@ -406,9 +407,19 @@ case "complete":
     guard let id = cmd.id else { fail("id is required for complete") }
     let reminder = findReminder(store, id: id)
     reminder.isCompleted = true
+    if let completionDate = cmd.completionDate {
+        // Setting isCompleted automatically sets completionDate to "now", so we
+        // override with our own completion date here.
+        guard let date = parseISO(completionDate) else { fail("Invalid completion date") }
+        reminder.completionDate = date
+    }
     do {
         try store.save(reminder, commit: true)
-        output(["status": "completed", "id": id])
+        var response: [String: Any] = ["status": "completed", "id": id]
+        if let completionDate = reminder.completionDate {
+            response["completionDate"] = isoFormatter.string(from: completionDate)
+        }
+        output(response)
     } catch {
         fail("Complete failed: \(error.localizedDescription)")
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3180,6 +3180,142 @@ class CliTests(unittest.TestCase):
     def test_cmd_done_is_bridge_first(self):
         self._assert_bridge_first("cmd_done", SimpleNamespace(id=1, json=True), "complete")
 
+    def _done_with_date(self, reminder, args, *, bridge_available=True, bridge_result=None):
+        """Run cmd_done capturing the bridge payload and stdout/stderr."""
+        out, err = io.StringIO(), io.StringIO()
+        with (
+            mock.patch.object(self.remctl, "open_db", return_value=None),
+            mock.patch.object(self.remctl, "q_reminder", return_value=reminder),
+            mock.patch.object(self.remctl, "bridge_available", return_value=bridge_available) as avail,
+            mock.patch.object(self.remctl, "bridge_call", return_value=bridge_result) as bridge_call,
+            mock.patch.object(self.remctl, "osa_by_id_try", return_value=True) as osa_try,
+            contextlib.redirect_stdout(out),
+            contextlib.redirect_stderr(err),
+        ):
+            try:
+                self.remctl.cmd_done(args)
+                exit_code = None
+            except SystemExit as exc:
+                exit_code = exc.code
+        return SimpleNamespace(
+            avail=avail, bridge_call=bridge_call, osa_try=osa_try,
+            stdout=out.getvalue(), stderr=err.getvalue(), exit_code=exit_code,
+        )
+
+    def test_cmd_done_date_forwards_parsed_iso_to_bridge(self):
+        # --date is parsed CLI-side and reaches the bridge as a clean ISO string.
+        reminder = {**self._FAKE_REMINDER, "recurrence_frequency": None}
+        res = self._done_with_date(
+            reminder, SimpleNamespace(id=1, json=True, date="2026-05-27"),
+            bridge_result={"status": "completed", "id": reminder["ZCKIDENTIFIER"],
+                           "completionDate": "2026-05-27T07:00:00Z"},
+        )
+        self.assertIsNone(res.exit_code)
+        payload = res.bridge_call.call_args.args[0]
+        self.assertEqual(payload["action"], "complete")
+        self.assertEqual(payload["completionDate"], "2026-05-27T00:00:00")
+        # JSON echoes local-naive ISO (like dueDate) — same value the AppleScript
+        # path emits, regardless of the bridge's UTC echo or the local timezone.
+        self.assertEqual(json.loads(res.stdout)["completionDate"], "2026-05-27T00:00:00")
+        res.osa_try.assert_not_called()
+
+    def test_cmd_done_date_accepts_due_style_shortcut(self):
+        # --date speaks the same vocabulary as --due, not just strict ISO.
+        reminder = {**self._FAKE_REMINDER, "recurrence_frequency": None}
+        res = self._done_with_date(
+            reminder, SimpleNamespace(id=1, json=True, date="today"),
+            bridge_result={"status": "completed", "id": reminder["ZCKIDENTIFIER"]},
+        )
+        expected = self.remctl.datetime.now().replace(
+            hour=0, minute=0, second=0, microsecond=0).isoformat()
+        self.assertEqual(res.bridge_call.call_args.args[0]["completionDate"], expected)
+
+    def test_cmd_done_date_rejected_for_recurring_reminder(self):
+        # A supplied completion date is silently ignored for recurring reminders, so refuse it.
+        reminder = {**self._FAKE_REMINDER, "recurrence_frequency": "daily"}
+        res = self._done_with_date(
+            reminder, SimpleNamespace(id=1, json=False, date="2026-05-27"))
+        self.assertEqual(res.exit_code, 1)
+        res.bridge_call.assert_not_called()
+        self.assertIn("recurring", res.stderr)
+
+    def test_cmd_done_date_rejected_for_recurring_reminder_json(self):
+        # --json mode emits a structured error, not bare text.
+        reminder = {**self._FAKE_REMINDER, "recurrence_frequency": "daily"}
+        res = self._done_with_date(
+            reminder, SimpleNamespace(id=1, json=True, date="2026-05-27"))
+        self.assertEqual(res.exit_code, 1)
+        res.bridge_call.assert_not_called()
+        payload = json.loads(res.stderr)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["code"], "date_unsupported_for_recurring")
+
+    def test_cmd_done_recurring_without_date_still_completes(self):
+        # The guard must not block ordinary completion of a recurring reminder.
+        reminder = {**self._FAKE_REMINDER, "recurrence_frequency": "daily"}
+        res = self._done_with_date(
+            reminder, SimpleNamespace(id=1, json=True),
+            bridge_result={"status": "completed", "id": reminder["ZCKIDENTIFIER"]},
+        )
+        self.assertIsNone(res.exit_code)
+        res.bridge_call.assert_called_once()
+        self.assertEqual(res.bridge_call.call_args.args[0]["action"], "complete")
+
+    def test_cmd_done_date_via_applescript_fallback(self):
+        # With the bridge unavailable, --date completes via AppleScript and sets
+        # the completion date in the same action (no bridge required).
+        reminder = {**self._FAKE_REMINDER, "recurrence_frequency": None}
+        res = self._done_with_date(
+            reminder, SimpleNamespace(id=1, json=False, date="2026-05-27"),
+            bridge_available=False)
+        self.assertIsNone(res.exit_code)
+        res.bridge_call.assert_not_called()
+        res.osa_try.assert_called_once()
+        action = res.osa_try.call_args.args[2]
+        self.assertIn("set completed of r to true", action)
+        self.assertIn("set completion date of r to d", action)
+        self.assertIn("set year of d to 2026", action)
+        self.assertIn("set month of d to 5", action)
+        self.assertIn("set day of d to 27", action)
+
+    def test_cmd_done_date_via_applescript_fallback_json(self):
+        # JSON output on the AppleScript path echoes the completion date.
+        reminder = {**self._FAKE_REMINDER, "recurrence_frequency": None}
+        res = self._done_with_date(
+            reminder, SimpleNamespace(id=1, json=True, date="2026-05-27"),
+            bridge_available=False)
+        self.assertIsNone(res.exit_code)
+        res.osa_try.assert_called_once()
+        payload = json.loads(res.stdout)
+        self.assertEqual(payload["status"], "completed")
+        self.assertEqual(payload["completionDate"], "2026-05-27T00:00:00")
+
+    def test_cmd_done_invalid_date_fails_fast(self):
+        # Unparseable --date fails before any bridge work.
+        reminder = {**self._FAKE_REMINDER, "recurrence_frequency": None}
+        res = self._done_with_date(
+            reminder, SimpleNamespace(id=1, json=False, date="zzznotadatezzz"))
+        self.assertEqual(res.exit_code, 2)
+        res.avail.assert_not_called()
+        res.bridge_call.assert_not_called()
+        self.assertIn("could not parse date", res.stderr)
+
+    def test_osa_set_completion_date_script(self):
+        # The AppleScript snippet builds the date from integer components
+        # (locale-independent) and guards against month-length overflow by
+        # setting day=1 before changing the month.
+        script = self.remctl.osa_set_completion_date_script(
+            self.remctl.datetime(2026, 5, 27, 9, 30, 15))
+        self.assertIn("set year of d to 2026", script)
+        self.assertIn("set month of d to 5", script)
+        self.assertIn("set day of d to 27", script)
+        self.assertIn("set completion date of r to d", script)
+        # 9*3600 + 30*60 + 15 = 34215 seconds into the day
+        self.assertIn("set time of d to 34215", script)
+        # day is reset to 1 before the month is set, to avoid overflow
+        self.assertLess(script.index("set day of d to 1\n"),
+                        script.index("set month of d to 5"))
+
     def test_cmd_undone_is_bridge_first(self):
         self._assert_bridge_first("cmd_undone", SimpleNamespace(id=1, json=True), "uncomplete")
 


### PR DESCRIPTION
## Summary

Adds the ability to complete a reminder (or update an already completed reminder) with an explicit completion date/time instead of "now". By default EventKit stamps a completion at the current time; this lets you record that a reminder was finished at a specific past — or future — moment.

```
remctl done <id> --date 2026-05-27
remctl done <id> --date "2026-05-27 09:30"
```

## Motivation

When you forget to tick something off on the day you actually finished it, the recorded completion ends up wrong, and there's no way in the Reminders UI to fix it after the fact. This fills that gap from the CLI. (Concrete use case: periodic reminders I often complete a day or two late.)

## Behaviour decisions

- **Recurring reminders are rejected.** Completing a recurring reminder makes EventKit advance the series and *discard* any `completionDate` set, so `done --date` on a recurring reminder errors and points at plain `done` (which still advances the series correctly). Plain completion of recurring reminders is unchanged.
- **Future dates are allowed.** EventKit stores them verbatim and nothing else in the CLI range-validates dates, so this stays consistent rather than adding a special case.

## Open question — should amending live on edit?

`done --date` also amends an already-completed reminder's completion date (the same code path re-stamps `completionDate`). That second use case — correcting an existing completion rather than completing something — arguably fits `edit` (a property change, parallel to `edit -d` for due dates) better than `done` (a state transition). I kept it all on `done --date` to keep this change small and avoid an `edit`-side surface that would duplicate the recurring/bridge guards and introduce an implicit-complete when a completion date is given for an incomplete reminder.


