### PR TITLE
Fix case-sensitive sharee assignment matching

### DIFF
--- a/remctl
+++ b/remctl
@@ -801,6 +801,17 @@ def list_ref_payload(row, *, requested=None, method="exact"):
     return payload
 
 
+def _ckid_eq(a, b):
+    """Case-insensitive CloudKit identifier comparison.
+
+    uuid_from_blob() upper-cases UUIDs decoded from BLOB columns such as
+    ZSHAREDOWNERIDENTIFIER, but ZCKIDENTIFIER text columns are stored
+    lower-cased by the live Reminders store, so a direct == never matches
+    a current-user/owner sharee on device.
+    """
+    return bool(a) and bool(b) and str(a).upper() == str(b).upper()
+
+
 def sharee_to_dict(row, *, current_user_ckid=None):
     payload = {
         "id": _row_get(row, "Z_PK"),
@@ -820,7 +831,7 @@ def sharee_to_dict(row, *, current_user_ckid=None):
         payload["status"] = _row_get(row, "ZSTATUS")
     if _row_get(row, "ZACCESSLEVEL") is not None:
         payload["accessLevel"] = _row_get(row, "ZACCESSLEVEL")
-    if current_user_ckid and payload.get("objectUUID") == current_user_ckid:
+    if _ckid_eq(payload.get("objectUUID"), current_user_ckid):
         payload["currentUser"] = True
     return payload
 
@@ -855,7 +866,7 @@ def resolve_sharee_or_die(db, list_pk, value, *, allow_me=True):
             print("Error: could not identify the current-user sharee for this list.", file=sys.stderr)
             sys.exit(1)
         for sharee in sharees:
-            if _row_get(sharee, "ZCKIDENTIFIER") == current_user_ckid:
+            if _ckid_eq(_row_get(sharee, "ZCKIDENTIFIER"), current_user_ckid):
                 return sharee
         print("Error: current-user sharee is not present in this list.", file=sys.stderr)
         sys.exit(1)
@@ -903,7 +914,7 @@ def resolve_assignment_originator_or_die(db, list_pk):
         print("Error: could not identify the current-user sharee for assignment originator.", file=sys.stderr)
         sys.exit(1)
     for sharee in q_sharees(db, list_pk):
-        if _row_get(sharee, "ZCKIDENTIFIER") == owner_ckid:
+        if _ckid_eq(_row_get(sharee, "ZCKIDENTIFIER"), owner_ckid):
             return sharee
     print("Error: current-user sharee is not present in this list.", file=sys.stderr)
     sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2635,6 +2635,43 @@ class CliTests(unittest.TestCase):
         self.assertIn("alex.second@example.com", stderr.getvalue())
         db.close()
 
+    def _sharee_db_lowercase(self):
+        # The live Reminders store records ZCKIDENTIFIER lower-cased, while the
+        # owner blob decodes upper-cased via uuid_from_blob(); mirror that.
+        db = sqlite3.connect(":memory:")
+        db.row_factory = sqlite3.Row
+        db.executescript("""
+            CREATE TABLE ZREMCDBASELIST (
+                Z_PK INTEGER PRIMARY KEY, ZSHAREDOWNERIDENTIFIER BLOB,
+                ZMARKEDFORDELETION INTEGER DEFAULT 0, Z_ENT INTEGER DEFAULT 3);
+            CREATE TABLE ZREMCDOBJECT (
+                Z_PK INTEGER PRIMARY KEY, Z_ENT INTEGER,
+                ZMARKEDFORDELETION INTEGER DEFAULT 0, ZLIST INTEGER, ZCKIDENTIFIER TEXT,
+                ZDISPLAYNAME TEXT, ZFIRSTNAME TEXT, ZLASTNAME TEXT, ZADDRESS1 TEXT,
+                ZSTATUS INTEGER, ZACCESSLEVEL INTEGER);
+        """)
+        owner = uuid.UUID("EBA4B6AE-6FA9-4361-BA3D-F548DE185CDA")
+        db.execute("INSERT INTO ZREMCDBASELIST (Z_PK, ZSHAREDOWNERIDENTIFIER) VALUES (?, ?)",
+                   (7, owner.bytes))
+        db.executemany(
+            "INSERT INTO ZREMCDOBJECT (Z_PK, Z_ENT, ZLIST, ZCKIDENTIFIER, ZFIRSTNAME, ZLASTNAME, ZADDRESS1, ZSTATUS, ZACCESSLEVEL) "
+            "VALUES (?, 36, 7, ?, ?, ?, ?, 2, 2)",
+            [(10, "aaf651e6-f8d7-44fa-a71f-8ab3d69c5c5a", "Alex", "Example", "mailto:alex@example.com"),
+             (11, "eba4b6ae-6fa9-4361-ba3d-f548de185cda", "Current", "User", "mailto:current@example.com")])
+        return db
+
+    def test_resolve_me_matches_lowercased_current_user_ckid(self):
+        db = self._sharee_db_lowercase()
+        self.assertEqual(self.remctl.resolve_sharee_or_die(db, 7, "me")["ZCKIDENTIFIER"],
+                         "eba4b6ae-6fa9-4361-ba3d-f548de185cda")
+        db.close()
+
+    def test_resolve_assignment_originator_matches_lowercased_owner_ckid(self):
+        db = self._sharee_db_lowercase()
+        self.assertEqual(self.remctl.resolve_assignment_originator_or_die(db, 7)["ZCKIDENTIFIER"],
+                         "eba4b6ae-6fa9-4361-ba3d-f548de185cda")
+        db.close()
+
     def test_validate_private_args_rejects_assign_and_unassign_together(self):
         args = SimpleNamespace(
             assign="Alex",


### PR DESCRIPTION
## Problem

`--assign` (both `add --private --assign` and `edit --private --assign`) fails on a real shared list with:

```
Error: current-user sharee is not present in this list.
```

even when the target sharee is present and listed by `remctl sharees`. Shared-list assignment is unusable on device.

## Cause

`uuid_from_blob()` upper-cases UUIDs decoded from BLOB columns, so `q_list_shared_owner_ckid()` (reading `ZSHAREDOWNERIDENTIFIER`) returns an upper-cased CKID. But `ZCKIDENTIFIER` text columns are stored lower-cased by the live Reminders store. The owner/current-user lookups compared the two with a case-sensitive `==`, which never matches on device:

- `resolve_assignment_originator_or_die()` — hit by every assignment; raises the error above.
- `resolve_sharee_or_die()` `me` branch — `--assign me` can't resolve.
- `sharee_to_dict()` — the `currentUser` flag is never set in `sharees --json`.

The existing `_sharee_db()` fixture stores `ZCKIDENTIFIER` upper-cased, matching the upper-cased owner blob, which masked this.

## Fix

Add a small `_ckid_eq()` helper that compares CloudKit identifiers case-insensitively (and None-safely), and use it at the three comparison sites.

## Tests

Added `test_resolve_me_matches_lowercased_current_user_ckid` and `test_resolve_assignment_originator_matches_lowercased_owner_ckid`, built on a lower-cased-identifier fixture mirroring the live store. Both fail on the pre-fix code and pass after. Existing sharee/assignment tests are unchanged and still pass; `python3 -m unittest discover -s tests` shows no new failures.

🤖 Diagnosis and patch prepared with Claude; reviewed and tested before submitting.