### PR TITLE
Preserve all-day status when editing a reminder's due date

### DIFF
--- a/remctl
+++ b/remctl
@@ -6100,10 +6100,12 @@ def cmd_edit(a):
     # string was given so the user doesn't silently get a no-op write that
     # falls through to the broken bridge path.
     dt = None
+    due_all_day = False
     if a.due and a.due != "clear":
         dt = parse_due(a.due)
         if dt is None:
             fail_invalid_due_date(a.due, json_mode=getattr(a, "json", False))
+        due_all_day = due_spec_is_all_day(a.due)
     if early_reminder_requires_due_date(a) and a.due == "clear":
         fail_early_reminder_without_due(json_mode=getattr(a, "json", False))
     if early_reminder_requires_due_date(a) and dt is None and not r["ZDUEDATE"]:
@@ -6176,6 +6178,8 @@ def cmd_edit(a):
                 data["clearAlarms"] = True
         elif dt is not None:
             data["due"] = dt.isoformat(); has_changes = True
+            if due_all_day:
+                data["allDay"] = True
         if parsed_recurrence is not None:
             data["recurrence"] = parsed_recurrence; has_changes = True
         if clear_alarm:
@@ -6230,6 +6234,15 @@ def cmd_edit(a):
 
     if carry_absolute_alarm or clear_matching_absolute_alarm:
         print("Error: this edit requires remctl-bridge to keep due/display/alarm state aligned.", file=sys.stderr)
+        sys.exit(1)
+
+    # AppleScript cannot write date-only dueDateComponents, so all-day edits require the bridge.
+    if dt is not None and due_all_day:
+        message = "All-day due dates require remctl-bridge so Reminders can store date-only components."
+        if getattr(a, "json", False):
+            print(json.dumps({"status": "error", "code": "bridge_required_for_all_day", "message": message}), file=sys.stderr)
+        else:
+            print(f"Error: {message}", file=sys.stderr)
         sys.exit(1)
 
     # AppleScript fallback for when bridge isn't available.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3570,6 +3570,73 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["action"], "update")
         self.assertEqual(payload["due"], "2026-04-20T09:00:00")
 
+    def test_cmd_edit_passes_all_day_to_bridge_for_date_only_due(self):
+        reminder = self._FAKE_REMINDER
+        args = SimpleNamespace(
+            id=1, json=True, title=None, notes=None, priority=None,
+            due="2026-06-21", url=None, recurrence=None, alarm=None,
+        )
+        with (
+            mock.patch.object(self.remctl, "open_db", return_value=None),
+            mock.patch.object(self.remctl, "q_reminder", return_value=reminder),
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(
+                self.remctl, "bridge_call",
+                return_value={"status": "updated", "id": reminder["ZCKIDENTIFIER"]},
+            ) as bridge_call,
+            mock.patch.object(self.remctl, "osa_by_id_try", return_value=True),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_edit(args)
+        payload = bridge_call.call_args.args[0]
+        self.assertEqual(payload["due"], "2026-06-21T00:00:00")
+        self.assertTrue(payload["allDay"])
+
+    def test_cmd_edit_does_not_pass_all_day_for_timed_due(self):
+        reminder = self._FAKE_REMINDER
+        args = SimpleNamespace(
+            id=1, json=True, title=None, notes=None, priority=None,
+            due="2026-06-21 09:30", url=None, recurrence=None, alarm=None,
+        )
+        with (
+            mock.patch.object(self.remctl, "open_db", return_value=None),
+            mock.patch.object(self.remctl, "q_reminder", return_value=reminder),
+            mock.patch.object(self.remctl, "bridge_available", return_value=True),
+            mock.patch.object(
+                self.remctl, "bridge_call",
+                return_value={"status": "updated", "id": reminder["ZCKIDENTIFIER"]},
+            ) as bridge_call,
+            mock.patch.object(self.remctl, "osa_by_id_try", return_value=True),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.remctl.cmd_edit(args)
+        payload = bridge_call.call_args.args[0]
+        self.assertEqual(payload["due"], "2026-06-21T09:30:00")
+        self.assertNotIn("allDay", payload)
+
+    def test_cmd_edit_all_day_errors_when_bridge_unavailable(self):
+        # AppleScript can't write date-only dueDateComponents; error rather
+        # than silently demote to a midnight-timed reminder.
+        reminder = self._FAKE_REMINDER
+        args = SimpleNamespace(
+            id=1, json=False, title=None, notes=None, priority=None,
+            due="2026-06-21", url=None, recurrence=None, alarm=None,
+        )
+        with (
+            mock.patch.object(self.remctl, "open_db", return_value=None),
+            mock.patch.object(self.remctl, "q_reminder", return_value=reminder),
+            mock.patch.object(self.remctl, "bridge_available", return_value=False),
+            mock.patch.object(self.remctl, "bridge_call") as bridge_call,
+            mock.patch.object(self.remctl, "osa_by_id_try", return_value=True) as osa_try,
+            contextlib.redirect_stderr(io.StringIO()) as err,
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                self.remctl.cmd_edit(args)
+        self.assertEqual(raised.exception.code, 1)
+        bridge_call.assert_not_called()
+        osa_try.assert_not_called()
+        self.assertIn("remctl-bridge", err.getvalue())
+
     def test_cmd_edit_due_date_carries_matching_absolute_alarm(self):
         from datetime import datetime
 


### PR DESCRIPTION
## Summary

Editing an all-day reminder's due date with a date-only value silently demoted it to a midnight-timed reminder. After `remctl edit <id> -d 2026-06-21`, the reminder's `allDay` flag flipped to `false` and `displayDate` disappeared.

## Root cause

`cmd_add` already forwards an `allDay` flag to the bridge for date-only due values (added in 1.0.5), and the bridge already handles it. `cmd_edit` was missing the equivalent forwarding — it sent `due` but never `allDay`, so the bridge always wrote full date components with a timezone, EventKit derived `ZALLDAY=0`, and the reminder was demoted.

