### PR TITLE
Add uninstall.sh mirroring install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,31 @@ PREFIX="$HOME/.local" ./install.sh --bootstrap
 
 Full setup details live in [docs/installation.md](docs/installation.md).
 
+## Uninstalling
+
+To remove RemCTL, run the uninstaller from the repo:
+
+```bash
+./uninstall.sh
+```
+
+By default the uninstaller checks **both** default install locations — `~/bin` and `~/.local/bin` — so it works whether you installed with the default prefix or with `PREFIX="$HOME/.local"`. You do not need to know or remember which one you used.
+
+It removes the files `install.sh` created (the `remctl` CLI, the shared Python helpers, the compiled `remctl-bridge` / `remctl-permissions` / `remctl-private` binaries, the permissions icon, and the zsh completion) plus the config directory.
+
+If you installed to a different custom prefix, pass the same one you used to install:
+
+```bash
+PREFIX="$HOME/.local" ./uninstall.sh
+```
+
+Useful flags:
+
+- `--dry-run` previews what would be removed without deleting anything.
+- `--keep-config` leaves the config directory (`~/.config/remctl`) in place.
+
+The uninstaller only deletes files RemCTL created; it never runs `rm -rf` on the bin directory, and it removes the `completions` directory only when it is empty. It does not edit your shell config or revoke macOS permissions. After uninstalling, remove any `remctl` lines you added to `~/.zshrc` (PATH or completion `fpath` wiring), run `hash -r` (or open a new Terminal), and optionally revoke Reminders, Automation, and Full Disk Access for your terminal under System Settings > Privacy & Security.
+
 ## Command Map
 
 | Task | Commands |
@@ -394,6 +419,7 @@ remctl doctor
 | `scripts/live_edit_matrix.py` | Opt-in live edit-mode matrix for due/display/alarm regressions |
 | `scripts/live_private_matrix.py` | Opt-in live private command matrix using disposable Reminders data |
 | `install.sh` | Copy-based installer and bootstrap script |
+| `uninstall.sh` | Removes installed files and config (mirrors `install.sh`) |
 
 ## License
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# RemCTL Uninstaller
+# Removes remctl, remctl-bridge, remctl-private, remctl-permissions, shared
+# runtime helpers, zsh completion, and the config directory.
+#
+# Mirrors install.sh: it only deletes the exact files the installer created,
+# in both ~/bin and ~/.local/bin by default.
+
+set -euo pipefail
+
+DRY_RUN=0
+KEEP_CONFIG=0
+
+usage() {
+    cat <<'EOF'
+Usage: ./uninstall.sh [options]
+
+Options:
+  --dry-run        Show what would be removed without deleting anything
+  --keep-config    Do not remove the RemCTL config directory
+  -h, --help       Show this help text
+
+Notes:
+  By default this checks BOTH ~/bin and ~/.local/bin.
+  Override the target with PREFIX="$HOME/.local" or REMCTL_BIN_DIR=/custom/bin
+  to uninstall from a single location only.
+  Config dir defaults to ${XDG_CONFIG_HOME:-~/.config}/remctl.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)    DRY_RUN=1; shift ;;
+        --keep-config) KEEP_CONFIG=1; shift ;;
+        -h|--help)    usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+# Colors
+RED='\033[38;2;224;47;55m'
+GREEN='\033[38;2;97;187;70m'
+YELLOW='\033[38;2;253;181;21m'
+BLUE='\033[38;2;0;157;220m'
+DIM='\033[2m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Files the installer copies/compiles into the bin dir.
+FILES=(
+    remctl
+    remctl_runtime.py
+    remctl_serialization.py
+    remctl_smart_lists.py
+    remctl-bridge
+    remctl-permissions
+    remctl-permissions-icon.png
+    remctl-private
+    completions/_remctl
+)
+
+# Determine which bin dirs to clean.
+# If PREFIX or REMCTL_BIN_DIR is set, honor it (single target, same as installer).
+# Otherwise default to scanning both common locations.
+if [[ -n "${REMCTL_BIN_DIR:-}" ]]; then
+    BIN_DIRS=("$REMCTL_BIN_DIR")
+elif [[ -n "${PREFIX:-}" ]]; then
+    BIN_DIRS=("$PREFIX/bin")
+else
+    BIN_DIRS=("$HOME/bin" "$HOME/.local/bin")
+fi
+
+CONFIG_BASE="${XDG_CONFIG_HOME:-$HOME/.config}"
+CONFIG_DIR="${REMCTL_CONFIG_DIR:-$CONFIG_BASE/remctl}"
+
+echo ""
+echo -e "${BOLD}RemCTL Uninstaller${RESET}"
+[[ "$DRY_RUN" -eq 1 ]] && echo -e "${YELLOW}(dry run — nothing will be deleted)${RESET}"
+echo ""
+
+REMOVED=0
+
+remove_path() {
+    local target="$1"
+    if [[ -e "$target" || -L "$target" ]]; then
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+            echo -e "  ${YELLOW}would remove${RESET} $target"
+        else
+            rm -f "$target"
+            echo -e "  ${GREEN}✓${RESET} removed $target"
+        fi
+        REMOVED=$((REMOVED + 1))
+    fi
+}
+
+# 1. Remove installed files from each bin dir
+for BIN_DIR in "${BIN_DIRS[@]}"; do
+    [[ -d "$BIN_DIR" ]] || continue
+    echo -e "${BLUE}→${RESET} Checking $BIN_DIR ..."
+    for f in "${FILES[@]}"; do
+        remove_path "$BIN_DIR/$f"
+    done
+
+    # Remove the completions dir only if it is now empty
+    if [[ -d "$BIN_DIR/completions" ]]; then
+        if [[ -z "$(ls -A "$BIN_DIR/completions" 2>/dev/null)" ]]; then
+            if [[ "$DRY_RUN" -eq 1 ]]; then
+                echo -e "  ${YELLOW}would remove empty dir${RESET} $BIN_DIR/completions"
+            else
+                rmdir "$BIN_DIR/completions" 2>/dev/null \
+                    && echo -e "  ${GREEN}✓${RESET} removed empty dir $BIN_DIR/completions" || true
+            fi
+        else
+            echo -e "  ${DIM}left $BIN_DIR/completions (not empty)${RESET}"
+        fi
+    fi
+done
+
+# 2. Remove config directory
+if [[ "$KEEP_CONFIG" -eq 0 ]]; then
+    if [[ -d "$CONFIG_DIR" ]]; then
+        echo -e "${BLUE}→${RESET} Removing config directory ..."
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+            echo -e "  ${YELLOW}would remove${RESET} $CONFIG_DIR"
+        else
+            rm -rf "$CONFIG_DIR"
+            echo -e "  ${GREEN}✓${RESET} removed $CONFIG_DIR"
+        fi
+        REMOVED=$((REMOVED + 1))
+    fi
+else
+    echo -e "${DIM}Keeping config directory: $CONFIG_DIR${RESET}"
+fi
+
+echo ""
+if [[ "$REMOVED" -eq 0 ]]; then
+    echo -e "${YELLOW}Nothing found to remove.${RESET} RemCTL may already be uninstalled, or it was installed to a custom location."
+    echo -e "${DIM}Try: PREFIX=\"/your/prefix\" ./uninstall.sh${RESET}"
+else
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo -e "${GREEN}${BOLD}Dry run complete.${RESET} Re-run without --dry-run to delete."
+    else
+        echo -e "${GREEN}${BOLD}Done!${RESET} RemCTL files removed."
+    fi
+fi
+
+# 3. Things this script cannot safely auto-remove
+echo ""
+echo -e "${BOLD}Manual cleanup (not done automatically):${RESET}"
+echo -e "  ${DIM}• Shell config:${RESET} remctl setup may have added completion / PATH lines."
+echo -e "    Check ~/.zshrc for 'remctl' references and any 'export PATH=...bin' line you added."
+echo -e "  ${DIM}• macOS permissions:${RESET} revoke under System Settings → Privacy & Security"
+echo -e "    (Reminders, Automation, Full Disk Access) if you want a fully clean slate."
+echo -e "  ${DIM}Then run:${RESET} hash -r   ${DIM}(or open a new Terminal)${RESET}"
+echo ""


### PR DESCRIPTION
## Add `uninstall.sh`

Adds a companion uninstaller to `install.sh`. It removes the exact set of files the installer creates (the `remctl` CLI, the three `remctl_*.py` helpers, the compiled `remctl-bridge` / `remctl-permissions` / `remctl-private` binaries, the permissions icon, and `completions/_remctl`), plus the config directory.

### Details

- Honors the same `PREFIX`, `REMCTL_BIN_DIR`, and `XDG_CONFIG_HOME` overrides as the installer; defaults to checking both `~/bin` and `~/.local/bin`.
- Only deletes known files — never `rm -rf` on the bin directory.
- `--dry-run` to preview, `--keep-config` to retain config.
- Removes the `completions` dir only if empty.
- Intentionally does **not** edit `~/.zshrc` or revoke macOS permission grants; prints manual-cleanup notes instead.

Also adds an **Uninstalling** section to the README (after Quick Start) and a `uninstall.sh` row in the Project Layout table, matching the existing docs style.