### PR TITLE
edit: replace and remove synced tags (--set-tags / --clear-tags / --remove-tag)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -163,7 +163,8 @@ Private rich URLs require public `http` or `https` hosts. RemCTL rejects loopbac
 | Move to another list | `edit -l LIST` or `edit --list-id ID` | No | EventKit bridge first; if a pure move is rejected by a list/container boundary, RemCTL uses a verified ReminderKit clone-delete fallback and returns a new numeric `id` plus `oldId` |
 | Recurrence and normal alarms | `edit --recurrence`, `edit --alarm` | No | EventKit bridge only; verify in `info --json` |
 | Notes URL fallback | `edit --url URL` | No | Appends the URL to notes, not a rich attachment |
-| Rich web URL attachment and real tags | `edit --private --url URL -t tags` | Yes | Additive; does not remove or replace existing rich links |
+| Rich web URL attachment and real tags | `edit --private --url URL -t tags` | Yes | Additive; rich links are not removed/replaced. Tags can be replaced/removed (see next row) |
+| Replace or remove synced tags | `edit --private --set-tags a,b`, `--clear-tags`, `--remove-tag X` | Yes | Replaces the whole tag set via `set_tags` (clear-then-add); mutually exclusive with each other and additive `-t` |
 | Section assignment or creation | `edit --private --section`, `--section-id`, `--new-section` | Yes | If combined with `-l/--list`, section resolution uses the destination list |
 | Shared-list assignment | `add/edit --private --assign USER`, `edit --private --unassign` | Yes | `USER` resolves against `remctl sharees LIST`; accepts unique name, email/phone, numeric sharee ID, object UUID, or `me`; agents should prefer address or ID |
 | Subtasks | `edit --private --subtask ...` | Yes | Additive; rich JSON subtasks can include public and private child metadata |

--- a/docs/private-metadata.md
+++ b/docs/private-metadata.md
@@ -17,7 +17,7 @@ The helper is still experimental. It links a private framework, so Apple can ren
 Verified on macOS/iCloud sync:
 
 - web rich URL attachments to public HTTP(S) hosts: `--private --url https://example.com`
-- synced tags: `--private -t remctl,work`
+- synced tags (add): `--private -t remctl,work`
 - section assignment: `--private --section "Research"`
 - section assignment by stable ID: `--private --section-id DCD255E2-7CF5-4B45-9566-3F9A5D84AFA8`
 - section creation and assignment: `--private --new-section "Research"`
@@ -33,6 +33,21 @@ Verified on macOS/iCloud sync:
 - list groups: `group-create "Writing" --private --add-list Editorial`, `list-create "Ideas" --private --group Writing`, `group-edit "Writing" --private --add-list Ideas --remove-list Socials`, `group-edit "Writing" --private --move-list Ideas --last`, and `group-delete "Writing" --private --force`
 - custom smart lists with verified materializing Reminders filters: `smart-list-create "Flagged Review" --private --flagged`, `smart-list-create "Priority or Today" --private --match any --priority high,medium --date today`, `smart-list-create "Projects Today" --private --include-list Projects --date today --date-today-include-past-due`, and exact custom smart-list cleanup via `smart-list-delete "Flagged Review" --private --force`
 - Reminders templates: `template-create "Packing Template" --from-list Packing --private`, `template-apply "Packing Template" --private`, and exact cleanup via `template-delete "Packing Template" --private --force`
+
+Tag replacement and removal (new; verify on your store before relying on it):
+
+Unlike rich links and images, synced tags can be replaced or removed, because
+ReminderKit's `REMReminderHashtagContextChangeItem` exposes `removeAllHashtags`
+alongside `addHashtagWithType:name:`. The `set_tags` action clears the
+reminder's hashtags and then adds the requested set (an empty set clears all):
+
+- replace the whole set: `edit ID --private --set-tags remctl,work`
+- clear all tags: `edit ID --private --clear-tags`
+- remove specific tags: `edit ID --private --remove-tag work` (repeatable)
+
+`--remove-tag` reads the reminder's current tags and rewrites the survivors.
+These are mutually exclusive with each other and with additive `-t/--tags`.
+Verify with `info ID --json` and a second device, as with any private write.
 
 Not exposed:
 
@@ -72,6 +87,9 @@ With `--private`, `--url` creates a web rich link attachment and `-t/--tags` cre
 ```bash
 remctl edit 23880 --private --url "https://example.com"
 remctl edit 23880 --private -t remctl,work
+remctl edit 23880 --private --set-tags remctl,work
+remctl edit 23880 --private --clear-tags
+remctl edit 23880 --private --remove-tag work
 remctl edit 23880 --private --section "Research"
 remctl edit 23880 --private --section-id DCD255E2-7CF5-4B45-9566-3F9A5D84AFA8
 remctl edit 23880 --private --new-section "Inbox Zero"

--- a/remctl
+++ b/remctl
@@ -4411,6 +4411,9 @@ def private_changes_from_args(a):
     return any([
         getattr(a, "url", None),
         getattr(a, "tags", None),
+        getattr(a, "set_tags", None) is not None,
+        getattr(a, "clear_tags", False),
+        getattr(a, "remove_tag", None),
         getattr(a, "grocery", False),
         getattr(a, "section", None),
         getattr(a, "section_id", None),
@@ -4431,6 +4434,9 @@ def private_changes_from_args(a):
 
 def private_only_changes_from_args(a):
     return any([
+        getattr(a, "set_tags", None) is not None,
+        getattr(a, "clear_tags", False),
+        getattr(a, "remove_tag", None),
         getattr(a, "grocery", False),
         getattr(a, "section", None),
         getattr(a, "section_id", None),
@@ -4568,6 +4574,45 @@ def apply_private_changes(reminder_ckid, a, db=None, list_pk=None):
     results = []
     tags = split_csv(getattr(a, "tags", None))
     urls = [getattr(a, "url")] if getattr(a, "url", None) else []
+
+    # Tag replacement/removal. `-t/--tags` is additive (append); --set-tags,
+    # --clear-tags, and --remove-tag replace the reminder's whole synced tag set
+    # via the `set_tags` action, which the helper applies as clear-then-add.
+    set_tags = getattr(a, "set_tags", None)
+    clear_tags = getattr(a, "clear_tags", False)
+    remove_tags = [t.lstrip("#") for t in (getattr(a, "remove_tag", None) or [])]
+    replace_modes = sum(bool(x) for x in (set_tags is not None, clear_tags, bool(remove_tags)))
+    if replace_modes and tags:
+        print(
+            "Error: -t/--tags (add) cannot be combined with --set-tags/--clear-tags/--remove-tag.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if replace_modes > 1:
+        print(
+            "Error: pass only one of --set-tags, --clear-tags, --remove-tag.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    replace_tags = None
+    if clear_tags:
+        replace_tags = []
+    elif set_tags is not None:
+        replace_tags = [t.lstrip("#") for t in split_csv(set_tags)]
+    elif remove_tags:
+        if db is None:
+            db = open_db()
+        current = [t["ZNAME"] for t in q_hashtags(db, a.id)]
+        drop = {t.lower() for t in remove_tags}
+        replace_tags = [t for t in current if t.lower() not in drop]
+
+    if replace_tags is not None:
+        results.append(private_action({
+            "action": "set_tags",
+            "id": reminder_ckid,
+            "tags": replace_tags,
+        }))
 
     if urls or tags:
         results.append(private_action({
@@ -9156,6 +9201,9 @@ _remctl() {
                 '--early-reminder[Set Early Reminder delta, e.g. 15m, 1h, clear]:delta:' \
                 '--url[URL, web rich link with --private]:url:' \
                 '(-t --tags)'{-t,--tags}'[Tags, synced with --private]:tags:' \
+                '--set-tags[Replace all synced tags with --private]:tags:' \
+                '--clear-tags[Remove all synced tags with --private]' \
+                '--remove-tag[Remove a synced tag with --private]:tag:' \
                 '(-l --list)'{-l,--list}'[Target list]:list:' \
                 '--list-id[Target list by stable numeric ID]:id:' \
                 '(-d --due)'{-d,--due}'[Due date]:due:' \
@@ -9403,7 +9451,7 @@ BASH_COMPLETION = '''_remctl() {
         COMPREPLY=( $(compgen -W "--date --json" -- "$cur") )
         return
     elif [ "$cmd" = "edit" ]; then
-        COMPREPLY=( $(compgen -W "--private --grocery --section --section-id --new-section --subtask --image --assign --unassign --flagged --no-flagged --urgent --no-urgent --early-reminder --location-title --latitude --longitude --radius --proximity --title --list -l --list-id --url --tags -t --notes -n --due -d --priority -p --recurrence --alarm --json" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--private --grocery --section --section-id --new-section --subtask --image --assign --unassign --flagged --no-flagged --urgent --no-urgent --early-reminder --location-title --latitude --longitude --radius --proximity --title --list -l --list-id --url --tags -t --set-tags --clear-tags --remove-tag --notes -n --due -d --priority -p --recurrence --alarm --json" -- "$cur") )
         return
     elif [ "$cmd" = "doctor" ]; then
         COMPREPLY=( $(compgen -W "--for-agent --json" -- "$cur") )
@@ -10751,6 +10799,9 @@ def main():
     c.add_argument("--private", action="store_true", help="Use guarded Reminders metadata writes for URL/tags/sections/assignments/subtasks/images/location alarms")
     c.add_argument("--private-metadata", action="store_true", help=argparse.SUPPRESS)
     c.add_argument("-t", "--tags", help="Private metadata: add comma-separated synced hashtag labels")
+    c.add_argument("--set-tags", help="Private metadata: replace ALL synced hashtag labels with this comma-separated set")
+    c.add_argument("--clear-tags", action="store_true", help="Private metadata: remove ALL synced hashtag labels")
+    c.add_argument("--remove-tag", action="append", metavar="TAG", help="Private metadata: remove a specific synced hashtag label (repeatable)")
     c.add_argument("--grocery", action="store_true", help="Private metadata: categorize this reminder in its Groceries list")
     c.add_argument("--section", help="Private metadata: assign to an existing section in the reminder's list")
     c.add_argument("--section-id", help="Private metadata: assign to a section by stable ID when names collide")

--- a/remctl-private.m
+++ b/remctl-private.m
@@ -127,6 +127,7 @@
 
 @interface REMReminderHashtagContextChangeItem : NSObject
 - (id)addHashtagWithType:(NSInteger)type name:(NSString *)name;
+- (void)removeAllHashtags;
 @end
 
 @interface REMReminderFlaggedContextChangeItem : NSObject
@@ -681,6 +682,7 @@ int main(int argc, const char * argv[]) {
             @"add_private_metadata",
             @"add_url_attachments",
             @"add_tags",
+            @"set_tags",
             @"add_subtasks",
             @"clone_reminder_tree_to_list",
             @"assign_section",
@@ -1542,6 +1544,16 @@ int main(int argc, const char * argv[]) {
             if (urls.count == 0) fail(@"At least one URL is required");
         } else if ([action isEqualToString:@"add_tags"]) {
             if (tags.count == 0) fail(@"At least one tag is required");
+        } else if ([action isEqualToString:@"set_tags"]) {
+            // Replace the reminder's entire synced tag set: clear all existing
+            // hashtags here, then the shared tag-apply block below adds `tags`
+            // (which may be empty to leave the reminder with no tags).
+            id hashtagContext = [change hashtagContext];
+            if (!hashtagContext || ![hashtagContext respondsToSelector:@selector(removeAllHashtags)]) {
+                fail(@"ReminderKit hashtag context does not support replacement");
+            }
+            [hashtagContext removeAllHashtags];
+            details[@"tagsReplaced"] = @YES;
         } else if ([action isEqualToString:@"add_subtasks"]) {
             NSArray<NSDictionary *> *subtaskSpecs = subtaskSpecArray(cmd);
             if (subtaskSpecs.count == 0) fail(@"At least one subtask is required");
@@ -1714,7 +1726,7 @@ int main(int argc, const char * argv[]) {
                 addedURLs += 1;
             }
         }
-        if (([action isEqualToString:@"add_private_metadata"] || [action isEqualToString:@"add_tags"]) && tags.count) {
+        if (([action isEqualToString:@"add_private_metadata"] || [action isEqualToString:@"add_tags"] || [action isEqualToString:@"set_tags"]) && tags.count) {
             id hashtagContext = [change hashtagContext];
             for (NSString *tag in tags) {
                 [hashtagContext addHashtagWithType:1 name:tag];

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5896,5 +5896,86 @@ class CliTests(unittest.TestCase):
         self.assertEqual(identifiers, ["2C0EDC64-6294-488A-814F-46B44C8ABBD3"])
 
 
+class TagReplaceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.remctl = load_module("remctl_tagreplace_test", "remctl")
+
+    def _edit_args(self, **over):
+        base = dict(
+            private=True, private_metadata=False, id=42,
+            tags=None, url=None, grocery=False,
+            section=None, section_id=None, new_section=None,
+            subtask=None, image=None, assign=None, unassign=False,
+            flag=False, flagged=None, urgent=None, early_reminder=None,
+            location_title=None, latitude=None, longitude=None,
+            set_tags=None, clear_tags=False, remove_tag=None,
+        )
+        base.update(over)
+        return SimpleNamespace(**base)
+
+    def _capture(self, a, hashtags=None):
+        captured = []
+
+        def record(payload):
+            captured.append(payload)
+            return {"status": "ok"}
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mock.patch.object(self.remctl, "private_action", side_effect=record))
+            if hashtags is not None:
+                stack.enter_context(mock.patch.object(
+                    self.remctl, "q_hashtags",
+                    return_value=[{"ZNAME": t} for t in hashtags],
+                ))
+            self.remctl.apply_private_changes("CKID", a, db=object())
+        return captured
+
+    def test_set_tags_replaces_entire_set(self):
+        a = self._edit_args(set_tags="work,home")
+        self.assertEqual(
+            self._capture(a),
+            [{"action": "set_tags", "id": "CKID", "tags": ["work", "home"]}],
+        )
+
+    def test_clear_tags_sends_empty_set(self):
+        a = self._edit_args(clear_tags=True)
+        self.assertEqual(
+            self._capture(a),
+            [{"action": "set_tags", "id": "CKID", "tags": []}],
+        )
+
+    def test_remove_tag_computes_survivors_from_current(self):
+        a = self._edit_args(remove_tag=["home"])
+        self.assertEqual(
+            self._capture(a, hashtags=["work", "home"]),
+            [{"action": "set_tags", "id": "CKID", "tags": ["work"]}],
+        )
+
+    def test_remove_tag_is_case_insensitive_and_strips_hash(self):
+        a = self._edit_args(remove_tag=["#HOME"])
+        self.assertEqual(
+            self._capture(a, hashtags=["work", "home"]),
+            [{"action": "set_tags", "id": "CKID", "tags": ["work"]}],
+        )
+
+    def test_additive_and_replace_are_mutually_exclusive(self):
+        a = self._edit_args(tags="x", set_tags="y")
+        with self.assertRaises(SystemExit):
+            self._capture(a)
+
+    def test_only_one_replace_mode_allowed(self):
+        a = self._edit_args(clear_tags=True, remove_tag=["x"])
+        with self.assertRaises(SystemExit):
+            self._capture(a)
+
+    def test_additive_tags_still_use_add_private_metadata(self):
+        a = self._edit_args(tags="work")
+        self.assertEqual(
+            self._capture(a),
+            [{"action": "add_private_metadata", "id": "CKID", "urls": [], "tags": ["work"]}],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`edit -t/--tags` is append-only: it can add synced hashtag labels but cannot remove or replace them, so dropping a tag means deleting and recreating the reminder. ReminderKit already exposes the missing piece, though, `REMReminderHashtagContextChangeItem` declares `removeAllHashtags` right alongside `addHashtagWithType:name:`. This PR wires it up.

New `set_tags` private action clears the reminder's hashtags, then adds the requested set (an empty set clears all). Three `edit` flags drive it:

| Flag | Effect |
|------|--------|
| `--set-tags a,b` | replace the whole synced tag set |
| `--clear-tags` | remove all synced tags |
| `--remove-tag X` (repeatable) | remove a specific tag (reads current tags, rewrites survivors) |

They are mutually exclusive with each other and with additive `-t/--tags`, and require `--private` like other ReminderKit writes.

## Why this is safe API-wise

A class-dump of `ReminderKit` (via the dyld shared cache) shows `REMReminderHashtagContextChangeItem` exposes `removeHashtag:`, `removeAllHashtags`, `setMutableHashtags:`, and `undeleteHashtagWithID:` (the last implies removals are CloudKit change-tracked). `set_tags` uses the same `REMSaveRequest` path as the existing add, just clear-then-add.

## Verified live (macOS 26, iCloud account)

On a throwaway list, against real Reminders through the recompiled `remctl-private`:

```
start                         tags: [beta, alpha]
edit --private --set-tags alpha,gamma   ->  [gamma, alpha]   # beta dropped, gamma added, alpha kept
edit --private --remove-tag alpha       ->  [gamma]
edit --private --clear-tags             ->  (none)
```

No duplicates, exact replacement. Confirmed in `info --json`. I verified local materialization only; I'd suggest confirming cross-device propagation on your setup as you do for other private writes (it uses the same change-tracked save path as the working add).

## Tests

7 new unit tests for the payload construction (`tests/test_cli.py::TagReplaceTests`), TDD red→green. Full `test_cli` suite passes except one pre-existing, environment-dependent test (`test_bundle_context_ignores_nonexistent_env_app_paths`) that also fails on a clean checkout here. Docs (`private-metadata.md`, `commands.md`) and zsh + bash completions updated.

## Notes

- The Objective-C helper compiles cleanly with the existing `install.sh` flags.
- Scoped to tags only; happy to follow up with section rename/delete separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
