### PR TITLE
sections: first-class create, rename, and delete

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -165,6 +165,7 @@ Private rich URLs require public `http` or `https` hosts. RemCTL rejects loopbac
 | Notes URL fallback | `edit --url URL` | No | Appends the URL to notes, not a rich attachment |
 | Rich web URL attachment and real tags | `edit --private --url URL -t tags` | Yes | Additive; does not remove or replace existing rich links |
 | Section assignment or creation | `edit --private --section`, `--section-id`, `--new-section` | Yes | If combined with `-l/--list`, section resolution uses the destination list |
+| Section create / rename / delete | `section-create NAME -l LIST`, `section-rename NAME --new-name NEW -l LIST`, `section-delete NAME -l LIST` | Yes | Manage sections as first-class objects; require `--private`; resolve by name within the list or `--section-id`; a deleted section's reminders move to the list's default area |
 | Shared-list assignment | `add/edit --private --assign USER`, `edit --private --unassign` | Yes | `USER` resolves against `remctl sharees LIST`; accepts unique name, email/phone, numeric sharee ID, object UUID, or `me`; agents should prefer address or ID |
 | Subtasks | `edit --private --subtask ...` | Yes | Additive; rich JSON subtasks can include public and private child metadata |
 | Image attachments | `edit --private --image PATH` | Yes | Additive; generic files/PDFs are rejected, and existing images are not removed/replaced |

--- a/docs/private-metadata.md
+++ b/docs/private-metadata.md
@@ -164,6 +164,29 @@ remctl group-delete --group-id 476 --private --force --json
 
 List groups are containers for lists, not containers for reminders. `groups` and `group-info` report active/completed/total counts from child lists. `group-create` creates the group and can move existing lists under it. `list-create --private --group` creates a new list directly under a group. `group-edit` renames the group, adds or removes child lists, and can reorder a child list with `--move-list` plus `--before-list`, `--after-list`, `--first`, or `--last`. `group-delete` detaches every child list to the top level before deleting the empty group. These operations update list parentage only; reminders stay in the same child lists and should be verified with `show <list> --json`, `groups --json`, or `show <group> --json`.
 
+## Section Examples
+
+Sections were previously read-only (`sections`) and writable only by assigning a
+reminder (`add/edit --private --section`/`--new-section`). These manage sections
+as first-class objects:
+
+```bash
+remctl section-create "Research" -l Projects --private
+remctl section-rename "Research" --new-name "Reading" -l Projects --private
+remctl section-rename --section-id 794C4076-... --new-name "Reading" -l Projects --private
+remctl section-delete "Reading" -l Projects --private --force
+remctl sections --json     # read (unchanged)
+```
+
+`section-create` adds an empty section to the target list via
+`REMSaveRequest addListSectionWithDisplayName:`. `section-rename` fetches the
+section, opens a change item with `updateListSection:`, and sets `displayName`.
+`section-delete` opens the same change item and calls `removeFromList`; its
+reminders fall back to the list's default (unsectioned) area. All three require
+`--private`, resolve the section by name within `-l/--list` (use `--section-id`
+when names collide), and write through ReminderKit, not SQLite. Verify with
+`sections --json` or `show <list> --json`.
+
 ## Groceries List Examples
 
 ```bash

--- a/remctl
+++ b/remctl
@@ -8883,6 +8883,93 @@ def cmd_list_delete(a):
         print(f"Error: Failed to delete list '{target_name}'" + (f": {message}" if message else ""), file=sys.stderr)
         sys.exit(1)
 
+
+def _section_list_ref_or_die(db, a):
+    return resolve_required_list_target_or_die(
+        db, name=getattr(a, "list", None), list_id=getattr(a, "list_id", None),
+    )
+
+
+def cmd_section_create(a):
+    require_private_metadata(a)
+    db = open_db()
+    list_ref = _section_list_ref_or_die(db, a)
+    list_ckid = q_list_ckid(db, list_ref["id"])
+    if not list_ckid:
+        print("Error: target list has no stable CloudKit identifier.", file=sys.stderr)
+        sys.exit(1)
+    result = private_call({"action": "create_section", "listId": list_ckid, "name": a.name})
+    if not result or result.get("status") != "created":
+        message = result.get("message") if isinstance(result, dict) else "private helper failed"
+        print(f"Error: {message}", file=sys.stderr)
+        sys.exit(1)
+    if a.json:
+        print(json.dumps(
+            {"status": "created", "list": list_ref["title"], "name": a.name, "private": result},
+            ensure_ascii=False,
+        ))
+    else:
+        print(f"Created section: {safe_display(a.name)} in {safe_display(list_ref['title'])}")
+
+
+def cmd_section_rename(a):
+    require_private_metadata(a)
+    db = open_db()
+    list_ref = _section_list_ref_or_die(db, a)
+    section_ckid = resolve_section_ckid(
+        db, list_ref["id"],
+        section_name=getattr(a, "name", None), section_id=getattr(a, "section_id", None),
+    )
+    if not section_ckid:
+        print("Error: pass the section to rename by name or --section-id.", file=sys.stderr)
+        sys.exit(1)
+    result = private_call({"action": "rename_section", "sectionId": section_ckid, "name": a.new_name})
+    if not result or result.get("status") != "renamed":
+        message = result.get("message") if isinstance(result, dict) else "private helper failed"
+        print(f"Error: {message}", file=sys.stderr)
+        sys.exit(1)
+    if a.json:
+        print(json.dumps(
+            {"status": "renamed", "list": list_ref["title"], "sectionId": section_ckid,
+             "name": a.new_name, "private": result},
+            ensure_ascii=False,
+        ))
+    else:
+        print(f"Renamed section -> {safe_display(a.new_name)} in {safe_display(list_ref['title'])}")
+
+
+def cmd_section_delete(a):
+    require_private_metadata(a)
+    db = open_db()
+    list_ref = _section_list_ref_or_die(db, a)
+    section_ckid = resolve_section_ckid(
+        db, list_ref["id"],
+        section_name=getattr(a, "name", None), section_id=getattr(a, "section_id", None),
+    )
+    if not section_ckid:
+        print("Error: pass the section to delete by name or --section-id.", file=sys.stderr)
+        sys.exit(1)
+    if not a.force:
+        ans = input(
+            f"Delete a section in '{safe_display(list_ref['title'])}'? "
+            "Its reminders move to the list's default area. [y/N] "
+        )
+        if not ans.strip().lower().startswith("y"):
+            print("Cancelled.")
+            return
+    result = private_call({"action": "delete_section", "sectionId": section_ckid})
+    if not result or result.get("status") != "deleted":
+        message = result.get("message") if isinstance(result, dict) else "private helper failed"
+        print(f"Error: {message}", file=sys.stderr)
+        sys.exit(1)
+    if a.json:
+        print(json.dumps(
+            {"status": "deleted", "list": list_ref["title"], "sectionId": section_ckid, "private": result},
+            ensure_ascii=False,
+        ))
+    else:
+        print(f"Deleted section in {safe_display(list_ref['title'])}")
+
 def cmd_export(a):
     db = open_db()
     list_name = getattr(a, "list", None)
@@ -11019,6 +11106,34 @@ def main():
     c.add_argument("--list-id", type=int, help="Delete a list by stable numeric ID")
     c.add_argument("--force", action="store_true"); js(c)
 
+    c = sub.add_parser("section-create", help="Create a section in a list (requires --private)")
+    c.add_argument("name", help="New section name")
+    c.add_argument("-l", "--list", help="Target list name")
+    c.add_argument("--list-id", type=int, help="Target list by stable numeric ID")
+    c.add_argument("--private", action="store_true", help="Use guarded ReminderKit writes (required)")
+    c.add_argument("--private-metadata", action="store_true", help=argparse.SUPPRESS)
+    js(c)
+
+    c = sub.add_parser("section-rename", help="Rename a section in a list (requires --private)")
+    c.add_argument("name", nargs="?", help="Existing section name (omit when using --section-id)")
+    c.add_argument("--new-name", required=True, help="New section name")
+    c.add_argument("-l", "--list", help="The section's list name")
+    c.add_argument("--list-id", type=int, help="The section's list by stable numeric ID")
+    c.add_argument("--section-id", help="Target the section by stable ID when names collide")
+    c.add_argument("--private", action="store_true", help="Use guarded ReminderKit writes (required)")
+    c.add_argument("--private-metadata", action="store_true", help=argparse.SUPPRESS)
+    js(c)
+
+    c = sub.add_parser("section-delete", help="Delete a section in a list (requires --private)")
+    c.add_argument("name", nargs="?", help="Existing section name (omit when using --section-id)")
+    c.add_argument("-l", "--list", help="The section's list name")
+    c.add_argument("--list-id", type=int, help="The section's list by stable numeric ID")
+    c.add_argument("--section-id", help="Target the section by stable ID when names collide")
+    c.add_argument("--force", action="store_true", help="Skip the confirmation prompt")
+    c.add_argument("--private", action="store_true", help="Use guarded ReminderKit writes (required)")
+    c.add_argument("--private-metadata", action="store_true", help=argparse.SUPPRESS)
+    js(c)
+
     c = sub.add_parser("export", help="Export reminders")
     c.add_argument("-l", "--list", help="Export only this list")
     c.add_argument("--list-id", type=int, help="Export only this list by stable numeric ID")
@@ -11193,6 +11308,9 @@ def main():
         "subtasks": cmd_subtasks,
         "info": cmd_info,
         "sections": cmd_sections,
+        "section-create": cmd_section_create,
+        "section-rename": cmd_section_rename,
+        "section-delete": cmd_section_delete,
         "sharees": cmd_sharees,
         "stats": cmd_stats,
         "link": cmd_link,

--- a/remctl-private.m
+++ b/remctl-private.m
@@ -26,6 +26,7 @@
 - (id)updateAccount:(id)account;
 - (id)updateReminder:(id)reminder;
 - (id)updateList:(id)list;
+- (id)updateListSection:(id)section;
 - (id)updateSmartList:(id)smartList;
 - (id)updateTemplate:(id)templateObject;
 - (id)addReminderWithTitle:(NSString *)title toReminderSubtaskContextChangeItem:(id)context;
@@ -184,6 +185,8 @@
 
 @interface REMListSectionChangeItem : NSObject
 - (id)remObjectID;
+- (void)setDisplayName:(NSString *)displayName;
+- (void)removeFromList;
 @end
 
 @interface REMListSectionContextChangeItem : NSObject
@@ -696,6 +699,9 @@ int main(int argc, const char * argv[]) {
             @"create_group",
             @"set_list_parent_group",
             @"delete_group",
+            @"create_section",
+            @"rename_section",
+            @"delete_section",
             @"set_list_appearance",
             @"set_list_pinned",
             @"set_smart_list_pinned",
@@ -932,6 +938,90 @@ int main(int argc, const char * argv[]) {
                 @"status": @"deleted",
                 @"action": action,
                 @"groupId": groupID,
+            });
+            return 0;
+        }
+        if ([action isEqualToString:@"create_section"]) {
+            NSString *listID = cmd[@"listId"];
+            NSString *name = cmd[@"name"];
+            if (![listID isKindOfClass:[NSString class]] || listID.length == 0) fail(@"listId is required");
+            if (![name isKindOfClass:[NSString class]] || name.length == 0) fail(@"name is required");
+            id listObjectID = [REMObjectID objectIDWithURL:listURL(listID)];
+            if (!listObjectID) fail(@"Could not build ReminderKit list object ID");
+            REMStore *store = [REMStore new];
+            id list = [store fetchListWithObjectID:listObjectID error:&error];
+            if (!list) fail(error.localizedDescription ?: @"List not found");
+            REMSaveRequest *save = [[REMSaveRequest alloc] initWithStore:store];
+            id listChange = [save updateList:list];
+            if (!listChange) fail(@"Could not create ReminderKit list change item");
+            id sectionContext = [listChange sectionsContextChangeItem];
+            id sectionChange = [save addListSectionWithDisplayName:name toListSectionContextChangeItem:sectionContext];
+            id sectionObjectID = [sectionChange remObjectID];
+            if (!sectionObjectID) fail(@"Could not create section object ID");
+            [sectionContext setUnsavedSectionIDsOrdering:@[sectionObjectID]];
+            [sectionContext setShouldUpdateSectionsOrdering:YES];
+            if (![save saveSynchronouslyWithError:&error]) {
+                fail(error.localizedDescription ?: @"ReminderKit section create failed");
+            }
+            output(@{
+                @"status": @"created",
+                @"action": action,
+                @"listId": listID,
+                @"name": name,
+                @"sectionURL": [[sectionObjectID urlRepresentation] absoluteString] ?: @"",
+            });
+            return 0;
+        }
+        if ([action isEqualToString:@"rename_section"]) {
+            NSString *sectionID = cmd[@"sectionId"];
+            NSString *name = cmd[@"name"];
+            if (![sectionID isKindOfClass:[NSString class]] || sectionID.length == 0) fail(@"sectionId is required");
+            if (![name isKindOfClass:[NSString class]] || name.length == 0) fail(@"name is required");
+            id sectionObjectID = [REMObjectID objectIDWithURL:sectionURL(sectionID)];
+            if (!sectionObjectID) fail(@"Could not build ReminderKit section object ID");
+            REMStore *store = [REMStore new];
+            id section = [store fetchListSectionWithObjectID:sectionObjectID error:&error];
+            if (!section) fail(error.localizedDescription ?: @"Section not found");
+            REMSaveRequest *save = [[REMSaveRequest alloc] initWithStore:store];
+            REMListSectionChangeItem *change = [save updateListSection:section];
+            if (!change) fail(@"Could not create ReminderKit section change item");
+            if (![change respondsToSelector:@selector(setDisplayName:)]) {
+                fail(@"ReminderKit section change item does not support rename");
+            }
+            [change setDisplayName:name];
+            if (![save saveSynchronouslyWithError:&error]) {
+                fail(error.localizedDescription ?: @"ReminderKit section rename failed");
+            }
+            output(@{
+                @"status": @"renamed",
+                @"action": action,
+                @"sectionId": sectionID,
+                @"name": name,
+            });
+            return 0;
+        }
+        if ([action isEqualToString:@"delete_section"]) {
+            NSString *sectionID = cmd[@"sectionId"];
+            if (![sectionID isKindOfClass:[NSString class]] || sectionID.length == 0) fail(@"sectionId is required");
+            id sectionObjectID = [REMObjectID objectIDWithURL:sectionURL(sectionID)];
+            if (!sectionObjectID) fail(@"Could not build ReminderKit section object ID");
+            REMStore *store = [REMStore new];
+            id section = [store fetchListSectionWithObjectID:sectionObjectID error:&error];
+            if (!section) fail(error.localizedDescription ?: @"Section not found");
+            REMSaveRequest *save = [[REMSaveRequest alloc] initWithStore:store];
+            REMListSectionChangeItem *change = [save updateListSection:section];
+            if (!change) fail(@"Could not create ReminderKit section change item");
+            if (![change respondsToSelector:@selector(removeFromList)]) {
+                fail(@"ReminderKit section change item does not support deletion");
+            }
+            [change removeFromList];
+            if (![save saveSynchronouslyWithError:&error]) {
+                fail(error.localizedDescription ?: @"ReminderKit section delete failed");
+            }
+            output(@{
+                @"status": @"deleted",
+                @"action": action,
+                @"sectionId": sectionID,
             });
             return 0;
         }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5896,5 +5896,64 @@ class CliTests(unittest.TestCase):
         self.assertEqual(identifiers, ["2C0EDC64-6294-488A-814F-46B44C8ABBD3"])
 
 
+class SectionCrudTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.remctl = load_module("remctl_sectioncrud_test", "remctl")
+
+    def _run(self, fn, a, *, list_ckid="LCK", section_ckid="SCK"):
+        captured = []
+
+        def record(payload):
+            captured.append(payload)
+            status = {
+                "create_section": "created",
+                "rename_section": "renamed",
+                "delete_section": "deleted",
+            }[payload["action"]]
+            return {"status": status}
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mock.patch.object(self.remctl, "open_db", return_value=object()))
+            stack.enter_context(mock.patch.object(
+                self.remctl, "resolve_required_list_target_or_die",
+                return_value={"id": 30, "title": "L"}))
+            stack.enter_context(mock.patch.object(self.remctl, "q_list_ckid", return_value=list_ckid))
+            stack.enter_context(mock.patch.object(self.remctl, "resolve_section_ckid", return_value=section_ckid))
+            stack.enter_context(mock.patch.object(self.remctl, "private_call", side_effect=record))
+            fn(a)
+        return captured
+
+    def test_section_create_builds_payload(self):
+        a = SimpleNamespace(private=True, private_metadata=False, name="Research",
+                            list="L", list_id=None, json=True)
+        self.assertEqual(
+            self._run(self.remctl.cmd_section_create, a),
+            [{"action": "create_section", "listId": "LCK", "name": "Research"}],
+        )
+
+    def test_section_rename_builds_payload(self):
+        a = SimpleNamespace(private=True, private_metadata=False, name="Research",
+                            section_id=None, new_name="Reading", list="L", list_id=None, json=True)
+        self.assertEqual(
+            self._run(self.remctl.cmd_section_rename, a),
+            [{"action": "rename_section", "sectionId": "SCK", "name": "Reading"}],
+        )
+
+    def test_section_delete_builds_payload(self):
+        a = SimpleNamespace(private=True, private_metadata=False, name="Reading",
+                            section_id=None, list="L", list_id=None, force=True, json=True)
+        self.assertEqual(
+            self._run(self.remctl.cmd_section_delete, a),
+            [{"action": "delete_section", "sectionId": "SCK"}],
+        )
+
+    def test_section_create_requires_private(self):
+        a = SimpleNamespace(private=False, private_metadata=False, name="Research",
+                            list="L", list_id=None, json=True)
+        with self.assertRaises(SystemExit):
+            self._run(self.remctl.cmd_section_create, a)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Sections are currently read-only (`sections`) and writable only as a side effect of assigning a reminder (`add/edit --private --section` / `--new-section`). ReminderKit models sections as first-class objects with the same change-item machinery that already backs full group CRUD, so this adds direct management:

```bash
remctl section-create "Research" -l Projects --private
remctl section-rename "Research" --new-name "Reading" -l Projects --private   # or --section-id
remctl section-delete "Reading"  -l Projects --private --force                # or --section-id
remctl sections --json   # read (unchanged)
```

## Implementation

New `remctl-private` actions, mirroring the existing list/group handlers:

| Action | ReminderKit path |
|--------|------------------|
| `create_section` | `updateList:` → `[listChange sectionsContextChangeItem]` → `addListSectionWithDisplayName:` → set ordering |
| `rename_section` | `fetchListSectionWithObjectID:` → `updateListSection:` → `setDisplayName:` |
| `delete_section` | `fetchListSectionWithObjectID:` → `updateListSection:` → `removeFromList` |

All three require `--private`, resolve the section by name within `-l/--list` (or `--section-id` when names collide via the existing `resolve_section_ckid`), and write through ReminderKit, not SQLite. A deleted section's reminders fall back to the list's default area.

## Verified live (macOS 26, iCloud account)

On a throwaway list, end to end, confirmed in `ZREMCDBASESECTION`:

```
section-create "Research"                 -> row: Research (ZMARKEDFORDELETION=0)
section-rename "Research" --new-name Reading  -> row: Reading
section-delete "Reading" --force          -> 0 active sections
```

Local materialization confirmed; as with other private writes, worth a second-device check for iCloud propagation.

## Tests / docs

4 unit tests for payload construction (`tests/test_cli.py::SectionCrudTests`). Full `test_cli` suite passes except the one pre-existing, environment-dependent `test_bundle_context_ignores_nonexistent_env_app_paths` (also fails on a clean checkout here). Docs (`private-metadata.md`, `commands.md`) updated. Helper compiles with the existing `install.sh` flags.

Separate from / independent of the tag replace-remove PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
