### PR TITLE
Add recurrence intervals (yearly x2) and Nth-weekday rules (monthly 4th-fri)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -193,9 +193,12 @@ remctl add "Weekly report" --recurrence weekly
 remctl add "Standup" --recurrence "weekly mon,wed,fri" --alarm 15m
 remctl add "Pay rent" --recurrence monthly
 remctl add "Annual review" --recurrence yearly
+remctl add "Check PO box" --recurrence "monthly 4th-fri"
+remctl add "Renew passport" --recurrence "yearly x10"
+remctl add "Clean water pitcher" --recurrence "weekly x2 thu"
 ```
 
-Recurring schedules and normal alarms use EventKit and work on both `add` and `edit`. Accepted recurrence forms are `daily`, `weekly`, `weekly mon,wed,fri`, `monthly`, `monthly 1,15`, and `yearly`; invalid recurrence, alarm, and priority values fail before writing. `info --json`, `show --json`, and other read commands decode the stored recurrence rows back into a stable `recurrence` object. Normal alarms appear in `info --json` as `alarms` entries; relative alarms include `relativeOffset`, `relativeOffsetMinutes`, and a label such as `15 minutes before due date`. Use `edit ID --alarm clear --json` to remove normal alarms.
+Recurring schedules and normal alarms use EventKit and work on both `add` and `edit`. Accepted recurrence forms are `daily`, `weekly`, `weekly mon,wed,fri`, `monthly`, `monthly 1,15`, `monthly 4th-fri` (the Nth weekday of each month; `-1-fri` is the last Friday), and `yearly`. Any form takes an optional `xN` interval token right after the frequency — `yearly x2` is every 2 years, `weekly x2 thu` is every other Thursday. Note that `monthly 5th-fri` follows EventKit semantics: months without a fifth Friday are silently skipped, so prefer `-1-fri` when you mean "last Friday". Invalid recurrence, alarm, and priority values fail before writing. `info --json`, `show --json`, and other read commands decode the stored recurrence rows back into a stable `recurrence` object. Normal alarms appear in `info --json` as `alarms` entries; relative alarms include `relativeOffset`, `relativeOffsetMinutes`, and a label such as `15 minutes before due date`. Use `edit ID --alarm clear --json` to remove normal alarms.
 
 Early Reminders:
 

--- a/remctl
+++ b/remctl
@@ -2730,6 +2730,37 @@ def _recurrence_from_item(item):
     return recurrence_from_row(item, ts=ts)
 
 
+def _recurrence_weekday_specs(recurrence):
+    """Return [(dayOfTheWeek, weekNumber)] pairs; weekNumber 0 means every week."""
+    detailed = recurrence.get("daysOfWeekDetailed") or []
+    if detailed:
+        return [
+            (int(item.get("dayOfTheWeek", 0)), int(item.get("weekNumber") or 0))
+            for item in detailed
+            if isinstance(item, dict) and item.get("dayOfTheWeek")
+        ]
+    days = recurrence.get("daysOfWeek") or []
+    weeks = recurrence.get("weekNumbers") or []
+    return [
+        (int(day), int(weeks[idx]) if idx < len(weeks) else 0)
+        for idx, day in enumerate(days)
+    ]
+
+
+def _weekday_spec_label(day, week):
+    name = RECURRENCE_DAY_NAMES.get(day, str(day))
+    if not week:
+        return name
+    if week == -1:
+        return f"last {name}"
+    if week < 0:
+        week = abs(week)
+        suffix = {1: "st", 2: "nd", 3: "rd"}.get(week if week < 20 else week % 10, "th")
+        return f"{week}{suffix}-last {name}"
+    suffix = {1: "st", 2: "nd", 3: "rd"}.get(week if week < 20 else week % 10, "th")
+    return f"{week}{suffix} {name}"
+
+
 def recurrence_summary(recurrence):
     if not recurrence:
         return ""
@@ -2749,10 +2780,9 @@ def recurrence_summary(recurrence):
     else:
         label = f"every {interval} {plural}"
 
-    days = recurrence.get("daysOfWeek") or []
-    if frequency == "weekly" and days:
-        names = [RECURRENCE_DAY_NAMES.get(int(day), str(day)) for day in days]
-        label += " " + ", ".join(names)
+    day_specs = _recurrence_weekday_specs(recurrence)
+    if frequency in ("weekly", "monthly", "yearly") and day_specs:
+        label += " " + ", ".join(_weekday_spec_label(day, week) for day, week in day_specs)
 
     days_of_month = recurrence.get("daysOfMonth") or []
     if frequency == "monthly" and days_of_month:
@@ -4016,7 +4046,8 @@ def parse_subtask_specs(values):
             if recurrence is None:
                 print(
                     "Error: subtask recurrence must be daily, weekly, monthly, yearly, "
-                    "'weekly mon,wed,fri', or 'monthly 1,15'.",
+                    "'weekly mon,wed,fri', 'monthly 1,15', 'monthly 4th-fri', or any "
+                    "with an 'xN' interval like 'yearly x2'.",
                     file=sys.stderr,
                 )
                 sys.exit(1)
@@ -6277,8 +6308,13 @@ def due_spec_is_all_day(s):
 
 # ── Recurrence / Alarm Parsing ───────────────────────────────────────────────
 
+RECURRENCE_DAY_MAP = {"sun": 1, "mon": 2, "tue": 3, "wed": 4, "thu": 5, "fri": 6, "sat": 7}
+# digit runs are length-bounded so int() can never trip CPython's int/str conversion limit
+NTH_WEEKDAY_RE = re.compile(r"^(-?\d{1,2})(?:st|nd|rd|th)?-(sun|mon|tue|wed|thu|fri|sat)$")
+
+
 def parse_recurrence(spec):
-    """Parse recurrence spec like 'daily', 'weekly mon,wed,fri', 'monthly 1,15'."""
+    """Parse recurrence spec like 'daily', 'weekly mon,wed,fri', 'monthly 1,15', 'monthly 4th-fri', 'yearly x2'."""
     if not spec:
         return None
     parts = spec.lower().split()
@@ -6287,26 +6323,50 @@ def parse_recurrence(spec):
     freq = parts[0]
     if freq not in {"daily", "weekly", "monthly", "yearly"}:
         return None
-    result = {"frequency": freq, "interval": 1}
+    interval = 1
+    # optional 'xN' interval token, e.g. 'yearly x2' = every 2 years
+    if len(parts) > 1 and parts[1].startswith("x") and parts[1][1:].isdecimal():
+        token = parts[1][1:]
+        if len(token) > 3:
+            return None
+        interval = int(token)
+        if interval < 1:
+            return None
+        parts = [freq] + parts[2:]
+    result = {"frequency": freq, "interval": interval}
     if freq == "weekly" and len(parts) > 1:
         if len(parts) != 2:
             return None
-        day_map = {"sun": 1, "mon": 2, "tue": 3, "wed": 4, "thu": 5, "fri": 6, "sat": 7}
         tokens = [d.strip() for d in parts[1].split(",") if d.strip()]
-        if not tokens or any(token not in day_map for token in tokens):
+        if not tokens or any(token not in RECURRENCE_DAY_MAP for token in tokens):
             return None
-        days = [day_map[token] for token in tokens]
+        days = [RECURRENCE_DAY_MAP[token] for token in tokens]
         if days: result["daysOfWeek"] = days
     elif freq == "monthly" and len(parts) > 1:
         if len(parts) != 2:
             return None
         tokens = [d.strip() for d in parts[1].split(",") if d.strip()]
-        if not tokens or not all(token.isdigit() for token in tokens):
+        if not tokens:
             return None
-        days = [int(token) for token in tokens]
-        if any(day < 1 or day > 31 for day in days):
+        if all(token.isdecimal() and len(token) <= 2 for token in tokens):
+            days = [int(token) for token in tokens]
+            if any(day < 1 or day > 31 for day in days):
+                return None
+            if days: result["daysOfMonth"] = days
+        elif all(NTH_WEEKDAY_RE.match(token) for token in tokens):
+            # 'monthly 4th-fri' = the 4th Friday of every month; '-1-fri' = last
+            days, weeks = [], []
+            for token in tokens:
+                m = NTH_WEEKDAY_RE.match(token)
+                week = int(m.group(1))
+                if week == 0 or week > 5 or week < -5:
+                    return None
+                days.append(RECURRENCE_DAY_MAP[m.group(2)])
+                weeks.append(week)
+            result["daysOfWeek"] = days
+            result["weekNumbers"] = weeks
+        else:
             return None
-        if days: result["daysOfMonth"] = days
     elif len(parts) > 1:
         return None
     return result
@@ -6315,7 +6375,9 @@ def parse_recurrence(spec):
 def fail_invalid_recurrence(value):
     print(
         f"Error: could not parse recurrence {value!r}. Use daily, weekly, "
-        "'weekly mon,wed,fri', 'monthly 1,15', monthly, or yearly.",
+        "'weekly mon,wed,fri', 'monthly 1,15', 'monthly 4th-fri' ('-1-fri' = "
+        "last Friday), monthly, yearly, or add an 'xN' interval like "
+        "'yearly x2'.",
         file=sys.stderr,
     )
     sys.exit(1)
@@ -11705,7 +11767,7 @@ def build_parser():
     c.add_argument("-f", "--flag", action="store_true", help="Set the reminder's real flagged state")
     c.add_argument("-t", "--tags", help="Comma-separated tags; inline #hashtags normally, synced Reminders tags with --private")
     c.add_argument("--url", help="URL; appended to notes normally, synced web rich link attachment with --private")
-    c.add_argument("--recurrence", help="Recurrence: daily, weekly, 'weekly mon,wed,fri', 'monthly 1,15', yearly (bridge only)")
+    c.add_argument("--recurrence", help="Recurrence: daily, weekly, 'weekly mon,wed,fri', 'monthly 1,15', 'monthly 4th-fri' ('-1-fri' = last Friday), yearly, or any with an 'xN' interval like 'yearly x2' (bridge only)")
     c.add_argument("--alarm", help="Alarm: 15m, 1h, 1d, or ISO datetime (bridge only)")
     c.add_argument("--private", action="store_true", help="Use unsupported private ReminderKit writes for URL/tags/sections/assignments/subtasks/images")
     c.add_argument("--private-metadata", action="store_true", help=argparse.SUPPRESS)
@@ -11781,7 +11843,7 @@ def build_parser():
     c.add_argument("-n", "--notes"); c.add_argument("-d", "--due", help="Due date; date-only forms create all-day reminders, explicit times create timed reminders, or clear")
     c.add_argument("-p", "--priority")
     c.add_argument("--url", help="URL; appended to notes normally, synced web rich link attachment with --private")
-    c.add_argument("--recurrence", help="Recurrence (bridge only)")
+    c.add_argument("--recurrence", help="Recurrence: daily, weekly, 'weekly mon,wed,fri', 'monthly 1,15', 'monthly 4th-fri' ('-1-fri' = last Friday), yearly, or any with an 'xN' interval like 'yearly x2' (bridge only)")
     c.add_argument("--alarm", help="Alarm: 15m, 1h, 1d, ISO datetime, or clear (bridge only)")
     c.add_argument("--private", action="store_true", help="Use guarded Reminders metadata writes for URL/tags/sections/assignments/subtasks/images/location alarms")
     c.add_argument("--private-metadata", action="store_true", help=argparse.SUPPRESS)

--- a/remctl-bridge.swift
+++ b/remctl-bridge.swift
@@ -39,6 +39,7 @@ struct RecurrenceSpec: Decodable {
     let frequency: String
     let interval: Int?
     let daysOfWeek: [Int]?
+    let weekNumbers: [Int]?
     let daysOfMonth: [Int]?
     let end: String?
 }
@@ -155,7 +156,26 @@ func buildRecurrenceRule(_ spec: RecurrenceSpec) -> EKRecurrenceRule? {
     if let days = spec.daysOfWeek {
         // Input: 1=Sun, 2=Mon ... 7=Sat → EKWeekday raw values match
         guard !days.isEmpty, days.allSatisfy({ 1...7 ~= $0 }) else { return nil }
-        let mapped = days.compactMap { EKWeekday(rawValue: $0).map { EKRecurrenceDayOfWeek($0) } }
+        // Optional parallel weekNumbers pin each day to the Nth week of the
+        // month/year (e.g. monthly + Fri week 4 = "4th Friday"); -1 = last.
+        // EventKit raises an uncatchable NSException for out-of-range or
+        // wrong-frequency weekNumbers, so validate here like the sibling fields.
+        let weeks = spec.weekNumbers ?? []
+        guard weeks.isEmpty || weeks.count == days.count else { return nil }
+        if weeks.contains(where: { $0 != 0 }) {
+            switch freq {
+            case .monthly: guard weeks.allSatisfy({ (-5...5).contains($0) }) else { return nil }
+            case .yearly:  guard weeks.allSatisfy({ (-53...53).contains($0) }) else { return nil }
+            default: return nil
+            }
+        }
+        let mapped = days.enumerated().compactMap { idx, raw -> EKRecurrenceDayOfWeek? in
+            guard let day = EKWeekday(rawValue: raw) else { return nil }
+            if idx < weeks.count, weeks[idx] != 0 {
+                return EKRecurrenceDayOfWeek(dayOfTheWeek: day, weekNumber: weeks[idx])
+            }
+            return EKRecurrenceDayOfWeek(day)
+        }
         guard mapped.count == days.count else { return nil }
         daysOfWeek = mapped
     }
@@ -449,6 +469,10 @@ func recurrencePayload(_ rule: EKRecurrenceRule) -> [String: Any] {
     ]
     if let days = rule.daysOfTheWeek, !days.isEmpty {
         payload["daysOfWeek"] = days.map { $0.dayOfTheWeek.rawValue }
+        // weekNumber 0 = every week; nonzero pins the Nth weekday ("4th Friday")
+        if days.contains(where: { $0.weekNumber != 0 }) {
+            payload["weekNumbers"] = days.map { $0.weekNumber }
+        }
     }
     if let days = rule.daysOfTheMonth, !days.isEmpty {
         payload["daysOfMonth"] = days.map { $0.intValue }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,6 +193,99 @@ class CliTests(unittest.TestCase):
         self.assertIsNone(self.remctl.parse_recurrence("weekly funday"))
         self.assertIsNone(self.remctl.parse_recurrence("monthly 0,32"))
 
+    def test_parse_recurrence_interval_token(self):
+        self.assertEqual(
+            self.remctl.parse_recurrence("yearly x2"),
+            {"frequency": "yearly", "interval": 2},
+        )
+        self.assertEqual(
+            self.remctl.parse_recurrence("weekly x2 thu"),
+            {"frequency": "weekly", "interval": 2, "daysOfWeek": [5]},
+        )
+        self.assertEqual(
+            self.remctl.parse_recurrence("monthly x6"),
+            {"frequency": "monthly", "interval": 6},
+        )
+        self.assertIsNone(self.remctl.parse_recurrence("yearly x0"))
+        self.assertIsNone(self.remctl.parse_recurrence("yearly x"))
+        self.assertIsNone(self.remctl.parse_recurrence("daily x2 extra"))
+        self.assertIsNone(self.remctl.parse_recurrence("yearly x1000"))
+        self.assertIsNone(self.remctl.parse_recurrence("yearly x²"))
+        self.assertIsNone(self.remctl.parse_recurrence("monthly ²"))
+        self.assertIsNone(self.remctl.parse_recurrence("yearly x" + "9" * 5000))
+
+    def test_parse_recurrence_nth_weekday_of_month(self):
+        self.assertEqual(
+            self.remctl.parse_recurrence("monthly 4th-fri"),
+            {
+                "frequency": "monthly",
+                "interval": 1,
+                "daysOfWeek": [6],
+                "weekNumbers": [4],
+            },
+        )
+        self.assertEqual(
+            self.remctl.parse_recurrence("monthly 1st-mon,3rd-mon"),
+            {
+                "frequency": "monthly",
+                "interval": 1,
+                "daysOfWeek": [2, 2],
+                "weekNumbers": [1, 3],
+            },
+        )
+        self.assertEqual(
+            self.remctl.parse_recurrence("monthly -1-fri"),
+            {
+                "frequency": "monthly",
+                "interval": 1,
+                "daysOfWeek": [6],
+                "weekNumbers": [-1],
+            },
+        )
+        self.assertIsNone(self.remctl.parse_recurrence("monthly 6th-fri"))
+        self.assertIsNone(self.remctl.parse_recurrence("monthly 0th-fri"))
+        self.assertIsNone(self.remctl.parse_recurrence("monthly 4th-funday"))
+        self.assertIsNone(self.remctl.parse_recurrence("monthly 4th-fri,15"))
+
+    def test_recurrence_summary_renders_nth_weekday(self):
+        self.assertEqual(
+            self.remctl.recurrence_summary(
+                {"frequency": "monthly", "interval": 1, "daysOfWeek": [6], "weekNumbers": [4]}
+            ),
+            "monthly 4th Fri",
+        )
+        self.assertEqual(
+            self.remctl.recurrence_summary(
+                {"frequency": "monthly", "interval": 1, "daysOfWeek": [6], "weekNumbers": [-1]}
+            ),
+            "monthly last Fri",
+        )
+        self.assertEqual(
+            self.remctl.recurrence_summary(
+                {"frequency": "monthly", "interval": 2, "daysOfWeek": [3], "weekNumbers": [4]}
+            ),
+            "every 2 months 4th Tue",
+        )
+        # SQLite read path delivers daysOfWeekDetailed instead of parallel arrays
+        self.assertEqual(
+            self.remctl.recurrence_summary(
+                {
+                    "frequency": "monthly",
+                    "interval": 1,
+                    "daysOfWeekDetailed": [{"dayOfTheWeek": 6, "weekNumber": 4}],
+                    "daysOfWeek": [6],
+                }
+            ),
+            "monthly 4th Fri",
+        )
+        # weekly rendering is unchanged
+        self.assertEqual(
+            self.remctl.recurrence_summary(
+                {"frequency": "weekly", "interval": 1, "daysOfWeek": [2, 4]}
+            ),
+            "weekly Mon, Wed",
+        )
+
     def test_private_call_returns_structured_error_payload(self):
         with mock.patch.object(
             self.remctl,


### PR DESCRIPTION
## What

Two additions to `--recurrence`:

1. **Interval token `xN`** — the bridge's already accepted arbitrary intervals, but the CLI hardcoded `interval: 1`, so schedules like "every 2 years" weren't expressible, which would throw off my "if it ain't in the to-do list I ain't doing it" lifestyle. 😅 Now: `yearly x2`, `monthly x6`, `weekly x2 thu` (every other Thursday). Bounded 1–999.

2. **Nth-weekday-of-month rules** — `monthly 4th-fri` is the 4th Friday of each month, `monthly -1-fri` the last Friday, `monthly 1st-mon,3rd-mon` both parse.

## Round-trip + display

- The bridge's recurrence read-back now emits `weekNumbers` whenever a day is pinned, so rules survive `--json` round-trips (the SQLite read path already carried the data in `daysOfWeekDetailed`).
- `recurrence_summary` renders the new shapes across `info` / `show` / list badges: `monthly 4th Fri`, `monthly last Fri`, `every 2 months 4th Tue`. Previously a pinned rule displayed as bare `monthly`, indistinguishable from an unrestricted monthly repeat.

## Hardening that fell out of review

This branch went through a multi-reviewer audit plus a cross-model adversarial pass before submission, and a few things it caught are included:

- The bridge validates `weekNumbers` range and frequency-compatibility at the boundary, matching its sibling `daysOfWeek`/`daysOfMonth` guards — EventKit raises an **uncatchable** `NSInvalidArgumentException` for out-of-range or wrong-frequency weekNumbers, so they must never reach it.
- `parse_recurrence` digit checks use `isdecimal()` with bounded lengths: `str.isdigit()` accepts Unicode superscripts that `int()` rejects (`yearly x²` previously tracebacked), and unbounded digit runs can trip CPython ≥3.11's int-conversion limit.
- The nth-weekday regex is hoisted to module scope alongside the file's other compiled patterns.
- `edit --recurrence`'s help now documents the it (it previously said only "Recurrence (bridge only)"), and `fail_invalid_recurrence` lists the new forms.
- docs/commands.md notes the EventKit semantics of `5th-fri` in short months (silently skipped; prefer `-1-fri` for "last").

## Tests

New unittest coverage for the interval token (including rejection of `x0`, `x1000`, `x²`, and a 5000-digit run), nth-weekday parsing (multi-day lists, negative weeks, out-of-range and mixed-format rejection), and `recurrence_summary` rendering from both the parallel-array and `daysOfWeekDetailed` shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)